### PR TITLE
Support browser methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,26 @@ The options can be either an object, an array, or a string. When it's an array, 
 
 returns: <[Promise]> Promise which is resolved when ther browser is closed.
 
+See [Puppeteer's browser.disconnect()](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#browserdisconnect) for more details.
+
+#### hccrawler.disconnect()
+
+returns: <[Promise]> Promise which is resolved when ther browser is disconnected.
+
+See [Puppeteer's browser.close()](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#browserclose) for more details.
+
+#### hccrawler.versions()
+
+returns: <[Promise]> Promise which is resolved with HeadlessChrome/Chromium version.
+
+See [Puppeteer's browser.version()](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#browserversion) for more details.
+
+#### hccrawler.wsEndpoint()
+
+returns: <[Promise]> Promise which is resolved with websocket url.
+
+See [Puppeteer's browser.wsEndpoint()](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#browserwsendpoint) for more details.
+
 #### crawler.onIdle()
 
 - returns: <[Promise]> Promise which is resolved when queues become empty.

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -36,6 +36,7 @@ class Crawler {
           .then(() => this._page.close())
           .then(() => void debugRequest(`Closed page for ${this._options.url}`));
       });
+    });
   }
 
   /**

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -36,7 +36,6 @@ class Crawler {
           .then(() => this._page.close())
           .then(() => void debugRequest(`Closed page for ${this._options.url}`));
       });
-    });
   }
 
   /**

--- a/lib/hccrawler.js
+++ b/lib/hccrawler.js
@@ -140,15 +140,6 @@ class HCCrawler {
   }
 
   /**
-   * Get the queue size
-   * @return {number} queue size
-   * @readonly
-   */
-  get queueSize() {
-    return this._pQueue.size + 1;
-  }
-
-  /**
    * @param {Object} options
    * @private
    */

--- a/lib/hccrawler.js
+++ b/lib/hccrawler.js
@@ -102,10 +102,41 @@ class HCCrawler {
   }
 
   /**
+   * Disconnect from the Chromium instance
+   * @return {Promise} resolved when ther crawler disconnected
+   */
+  disconnect() {
+    return this._browser.disconnect();
+  }
+
+  /**
+   * @return {Promise} resolved with HeadlessChrome/Chromium version
+   */
+  version() {
+    return this._browser.version();
+  }
+
+  /**
+   * @return {Promise} resolved with websocket url
+   */
+  wsEndpoint() {
+    return this._browser.wsEndpoint();
+  }
+
+  /**
    * @return {Promise} resolved when queue is empty
    */
   onIdle() {
     return this._pQueue.onIdle();
+  }
+
+  /**
+   * Get the queue size
+   * @return {number} queue size
+   * @readonly
+   */
+  get queueSize() {
+    return this._pQueue.size + 1;
   }
 
   /**


### PR DESCRIPTION
- Support [Puppeteer](https://github.com/GoogleChrome/puppeteer)'s `disconnect`, `versions` and `wsEndpoint` methods