### PR TITLE
Add maxRequest option

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ See [here](https://github.com/yujiosaka/headless-chrome-crawler/tree/master/exam
   * [crawler.version()](#crawlerversion)
   * [crawler.wsEndpoint()](#crawlerwsendpoint)
   * [crawler.onIdle()](#crawleronidle)
+  * [crawler.onEnd()](#crawleronend)
   * [crawler.queueSize](#crawlerqueuesize)
+  * [crawler.pendingQueueSize](#crawlerpendingQueueSize)
 
 ### class: HCCrawler
 
@@ -90,7 +92,8 @@ HCCrawler provides method to launch or connect to a HeadlessChrome/Chromium. It 
 #### HCCrawler.connect([options])
 
 * `options` <[Object]>
-  * `concurrency` <[number]> Maximum number of pages to open concurrently, defaults to `10`.
+  * `maxConcurrency` <[number]> Maximum number of pages to open concurrently, defaults to `10`.
+  * `maxRequest` <[number]> Maximum number of requests, defaults to `0`. Pass `0` to disable the limit.
 * returns: <Promise<HCCrawler>> Promise which resolves to HCCrawler instance.
 
 This method connects to an existing Chromium instance. The following options are passed straight to [puppeteer.connect([options])](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteerconnectoptions).
@@ -110,7 +113,8 @@ url, timeout, priority, delay, retryCount, retryDelay, jQuery, device, username,
 #### HCCrawler.launch([options])
 
 * `options` <[Object]>
-  * `concurrency` <[number]> Maximum number of pages to open concurrently, defaults to `10`.
+  * `maxConcurrency` <[number]> Maximum number of pages to open concurrently, defaults to `10`.
+  * `maxRequest` <[number]> Maximum number of requests, defaults to `0`. Pass `0` to disable the limit.
 * returns: <Promise<HCCrawler>> Promise which resolves to HCCrawler instance.
 
 The method launches a HeadlessChrome/Chromium instance. The following options are passed straight to [puppeteer.launch([options])](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteerlaunchoptions).
@@ -132,7 +136,7 @@ url, timeout, priority, delay, retryCount, retryDelay, jQuery, device, username,
 * `options` <[Object]>
   * `url` <[String]> Url to navigate to. The url should include scheme, e.g. `https://`.
   * `priority` <[number]> Basic priority of queues, defaults to `1`. Queues with larger priorities are preferred.
-  * `delay` <[number]> Number of milliseconds after each request, defaults to `0`. When delay is set, concurrency must be `1`.
+  * `delay` <[number]> Number of milliseconds after each request, defaults to `0`. When delay is set, maxConcurrency must be `1`.
   * `retryCount` <[number]> Number of limit when retry fails, defaults to `3`.
   * `retryDelay` <[number]> Number of milliseconds after each retry fails, defaults to `10000`.
   * `jQuery` <[boolean]> Whether to automatically add [jQuery](https://jquery.com) tag to page, defaults to `true`.
@@ -187,9 +191,17 @@ See [Puppeteer's browser.wsEndpoint()](https://github.com/GoogleChrome/puppeteer
 
 - returns: <[Promise]> Promise which is resolved when queues become empty.
 
+#### crawler.onEnd()
+
+- returns: <[Promise]> Promise which is resolved when request reaches max.
+
 #### crawler.queueSize
 
 * returns: <[number]> The size of queues. This property is read only.
+
+#### crawler.pendingQueueSize
+
+* returns: <[number]> The size of pending queues. This property is read only.
 
 ## Debugging tips
 

--- a/examples/delay.js
+++ b/examples/delay.js
@@ -1,7 +1,7 @@
 const HCCrawler = require('../');
 
 HCCrawler.launch({
-  concurrency: 1, // Concurrency must be 1 when delay is set
+  maxConcurrency: 1, // Max concurrency must be 1 when delay is set
   delay: 2000, // Delay 2000 millisecnds before each request is sent
   evaluatePage: (() => ({
     title: $('title').text(),

--- a/examples/priority-queue.js
+++ b/examples/priority-queue.js
@@ -1,7 +1,7 @@
 const HCCrawler = require('../');
 
 HCCrawler.launch({
-  concurrency: 1,
+  maxConcurrency: 1,
   evaluatePage: (() => ({
     title: $('title').text(),
     h1: $('h1').text(),

--- a/examples/skip-duplicates.js
+++ b/examples/skip-duplicates.js
@@ -3,7 +3,7 @@ const HCCrawler = require('../');
 const requestedObj = {};
 
 HCCrawler.launch({
-  concurrency: 1,
+  maxConcurrency: 1,
   evaluatePage: (() => ({
     title: $('title').text(),
     h1: $('h1').text(),

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 const devices = require('puppeteer/DeviceDescriptors');
 const { debugRequest, debugBrowser } = require('./helper');
 
-const PUPPETEER_GOTO_OPTIONS = [
+const PAGE_GOTO_OPTIONS = [
   'timeout',
   'waitUntil',
 ];
@@ -26,7 +26,7 @@ class Crawler {
    */
   crawl() {
     return this._prepare()
-      .then(() => this._page.goto(this._options.url, _.pick(this._options, PUPPETEER_GOTO_OPTIONS)))
+      .then(() => this._page.goto(this._options.url, _.pick(this._options, PAGE_GOTO_OPTIONS)))
       .then(_response => {
         const response = _.pick(_response, RESPONSE_FIELDS);
         return this._addJQuery()

--- a/lib/hccrawler.js
+++ b/lib/hccrawler.js
@@ -24,6 +24,10 @@ const PUPPETEER_LAUNCH_OPTIONS = [
   'env',
   'devtools',
 ];
+const HCCRAWLER_OPTIONS = [
+  'maxConcurrency',
+  'maxRequest',
+];
 
 const deviceNames = Object.keys(devices);
 
@@ -66,7 +70,8 @@ class HCCrawler {
   constructor(browser, options) {
     this._browser = browser;
     this._options = _.extend({
-      concurrency: 10,
+      maxConcurrency: 10,
+      maxRequest: 0,
       priority: 1,
       delay: 0,
       retryCount: 3,
@@ -74,8 +79,12 @@ class HCCrawler {
       jQuery: true,
     }, options);
     this._pQueue = new PQueue({
-      concurrency: this._options.concurrency,
+      concurrency: this._options.maxConcurrency,
     });
+    this._requestCount = 0;
+    this._resolveOnEnd = () => {
+      this._pQueue.pause();
+    };
   }
 
   /**
@@ -87,7 +96,7 @@ class HCCrawler {
       let mergedOptions = _.isString(_options) ? { url: _options } : _options;
       mergedOptions = _.extend({}, this._options, mergedOptions);
       this._validateOptions(mergedOptions);
-      this._pQueue.add(() => this._request(mergedOptions), {
+      this._pQueue.add(() => this._request(_.omit(mergedOptions, HCCRAWLER_OPTIONS)), {
         priority: mergedOptions.priority,
       });
     });
@@ -131,12 +140,34 @@ class HCCrawler {
   }
 
   /**
+   * @return {Promise} resolved when reached the max request
+   */
+  onEnd() {
+    return new Promise(resolve => {
+      const oldResolveOnEnd = this._resolveOnEnd;
+      this._resolveOnEnd = () => {
+        oldResolveOnEnd();
+        resolve();
+      };
+    });
+  }
+
+  /**
    * Get the queue size
    * @return {number} queue size
    * @readonly
    */
   get queueSize() {
-    return this._pQueue.size + 1;
+    return this._pQueue.size;
+  }
+
+  /**
+   * Get the pending count
+   * @return {number} pending count
+   * @readonly
+   */
+  get pendingQueueSize() {
+    return this._pQueue.pending;
   }
 
   /**
@@ -148,7 +179,7 @@ class HCCrawler {
     if (!options.evaluatePage) throw new Error('Evaluate page function must be defined!');
     if (!options.onSuccess) throw new Error('On success function must be defined!');
     if (options.device && !_.includes(deviceNames, options.device)) throw new Error('Specified device is not supported!');
-    if (options.delay > 0 && options.concurrency !== 1) throw new Error('Concurrency must be 1 when delay is set!');
+    if (options.delay > 0 && options.maxConcurrency !== 1) throw new Error('Max concurrency must be 1 when delay is set!');
   }
 
   /**
@@ -166,7 +197,8 @@ class HCCrawler {
         }
         return this._newPage(options)
           .then(crawler => crawler.crawl())
-          .then(() => delay(options.delay));
+          .then(() => delay(options.delay))
+          .then(() => void this._checkRequestCount());
       })
       .catch(err => {
         if (retryCount >= options.retryCount) throw new Error(`Retry give-up for requesting ${options.url}!`, err);
@@ -198,6 +230,16 @@ class HCCrawler {
   _newPage(options) {
     return this._browser.newPage()
       .then(page => new Crawler(page, options));
+  }
+
+  /**
+   * @private
+   */
+  _checkRequestCount() {
+    this._requestCount += 1;
+    if (this._options.maxRequest && this._requestCount >= this._options.maxRequest) {
+      this._resolveOnEnd();
+    }
   }
 }
 

--- a/test/hccrawler.test.js
+++ b/test/hccrawler.test.js
@@ -67,7 +67,11 @@ describe('HCCrawler', () => {
 
     context('when launched with necessary options', () => {
       before(() => (
-        HCCrawler.launch({ evaluatePage: _.noop, onSuccess: _.noop, device: 'iPhone 6' })
+        HCCrawler.launch({
+          evaluatePage: _.noop,
+          onSuccess: _.noop,
+          device: 'iPhone 6',
+        })
           .then(_crawler => {
             crawler = _crawler;
           })
@@ -182,9 +186,13 @@ describe('HCCrawler', () => {
       });
     });
 
-    context('when launched with concurrency: 1', () => {
+    context('when launched with maxConcurrency: 1', () => {
       before(() => (
-        HCCrawler.launch({ evaluatePage: _.noop, onSuccess: _.noop, concurrency: 1 })
+        HCCrawler.launch({
+          evaluatePage: _.noop,
+          onSuccess: _.noop,
+          maxConcurrency: 1,
+        })
           .then(_crawler => {
             crawler = _crawler;
           })
@@ -217,6 +225,36 @@ describe('HCCrawler', () => {
           });
       });
     });
+
+    context('when launched with maxRequest option', () => {
+      before(() => (
+        HCCrawler.launch({
+          evaluatePage: _.noop,
+          onSuccess: _.noop,
+          maxConcurrency: 1,
+          maxRequest: 2,
+        })
+          .then(_crawler => {
+            crawler = _crawler;
+          })
+      ));
+
+      after(() => crawler.close());
+
+      it('requests until maxRequest', () => {
+        assert.doesNotThrow(() => {
+          crawler.queue({ url: URL1 });
+          crawler.queue({ url: URL2 });
+          crawler.queue({ url: URL3 });
+        });
+        return crawler.onEnd()
+          .then(() => {
+            assert.equal(crawler.queueSize, 1);
+            assert.equal(crawler.pendingQueueSize, 1);
+            assert.equal(Crawler.prototype.crawl.callCount, 2);
+          });
+      });
+    });
   });
 
   context('when crawl fails', () => {
@@ -226,7 +264,10 @@ describe('HCCrawler', () => {
 
     context('when launched with necessary options', () => {
       before(() => (
-        HCCrawler.launch({ evaluatePage: _.noop, onSuccess: _.noop })
+        HCCrawler.launch({
+          evaluatePage: _.noop,
+          onSuccess: _.noop,
+        })
           .then(_crawler => {
             crawler = _crawler;
           })


### PR DESCRIPTION
close https://github.com/yujiosaka/headless-chrome-crawler/issues/10

- Rename `concurrency` to `maxConcurrency` option for consistency
- Add `maxRequest` option
- Add `crawler.onEnd()` function
- Add `crawler.pendingQueueSize` read-only property