### PR TITLE
1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.2.0] - 2017-12-11
+### Changed
+
+- Rename `ensureCacheClear` to `persistCache` option for [HCCrawler.connect([options])](https://github.com/yujiosaka/headless-chrome-crawler#hccrawlerconnectoptions) and [HCCrawler.launch([options])](https://github.com/yujiosaka/headless-chrome-crawler#hccrawlerlaunchoptions) options
+
 ## [1.1.2] - 2017-12-10
 ### Added
 
-- Support `maxRequest`, `allowedDomains` and `userAgent` option for [crawler.queue([options])](https://github.com/yujiosaka/headless-chrome-crawler#crawlerqueueoptions)
+- Support `maxRequest` option for [HCCrawler.connect([options])](https://github.com/yujiosaka/headless-chrome-crawler#hccrawlerconnectoptions) and [HCCrawler.launch([options])](https://github.com/yujiosaka/headless-chrome-crawler#hccrawlerlaunchoptions) options
+- Support `allowedDomains` and `userAgent` option for [crawler.queue([options])](https://github.com/yujiosaka/headless-chrome-crawler#crawlerqueueoptions)
 - Support pluggable cache
 - Add [crawler.setMaxRequest(maxRequest)](https://github.com/yujiosaka/headless-chrome-crawler#crawlersetmaxrequestmaxrequest), [crawler.pause()](https://github.com/yujiosaka/headless-chrome-crawler#crawlerpause) and [crawler.resume()](https://github.com/yujiosaka/headless-chrome-crawler#crawlerresume) methods
 - Add [crawler.pendingQueueSize](https://github.com/yujiosaka/headless-chrome-crawler#crawlerpendingqueuesize) and [crawler.requestedCount](https://github.com/yujiosaka/headless-chrome-crawler#crawlerrequestedcount) read-only properties

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.2.0] - 2017-12-11
 ### Changed
 
-- Rename `ensureCacheClear` to `persistCache` option for [HCCrawler.connect([options])](https://github.com/yujiosaka/headless-chrome-crawler#hccrawlerconnectoptions) and [HCCrawler.launch([options])](https://github.com/yujiosaka/headless-chrome-crawler#hccrawlerlaunchoptions) options
+- Rename `ensureCacheClear` to `persistCache` for [HCCrawler.connect([options])](https://github.com/yujiosaka/headless-chrome-crawler#hccrawlerconnectoptions) and [HCCrawler.launch([options])](https://github.com/yujiosaka/headless-chrome-crawler#hccrawlerlaunchoptions)'s options
 
 ## [1.1.2] - 2017-12-10
 ### Added
 
-- Support `maxRequest` option for [HCCrawler.connect([options])](https://github.com/yujiosaka/headless-chrome-crawler#hccrawlerconnectoptions) and [HCCrawler.launch([options])](https://github.com/yujiosaka/headless-chrome-crawler#hccrawlerlaunchoptions) options
-- Support `allowedDomains` and `userAgent` option for [crawler.queue([options])](https://github.com/yujiosaka/headless-chrome-crawler#crawlerqueueoptions)
-- Support pluggable cache
+- Support `maxRequest` for [HCCrawler.connect([options])](https://github.com/yujiosaka/headless-chrome-crawler#hccrawlerconnectoptions) and [HCCrawler.launch([options])](https://github.com/yujiosaka/headless-chrome-crawler#hccrawlerlaunchoptions)'s options
+- Support `allowedDomains` and `userAgent` for [crawler.queue([options])](https://github.com/yujiosaka/headless-chrome-crawler#crawlerqueueoptions)'s options'
+- Support SessionCache, RedisCache for Pluggable cache and provide a BaseCache interface for customizing caches
 - Add [crawler.setMaxRequest(maxRequest)](https://github.com/yujiosaka/headless-chrome-crawler#crawlersetmaxrequestmaxrequest), [crawler.pause()](https://github.com/yujiosaka/headless-chrome-crawler#crawlerpause) and [crawler.resume()](https://github.com/yujiosaka/headless-chrome-crawler#crawlerresume) methods
 - Add [crawler.pendingQueueSize](https://github.com/yujiosaka/headless-chrome-crawler#crawlerpendingqueuesize) and [crawler.requestedCount](https://github.com/yujiosaka/headless-chrome-crawler#crawlerrequestedcount) read-only properties
 
@@ -34,14 +34,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.1.0] - 2017-12-08
 ### Added
 
-- Support `extraHeaders` option for [crawler.queue([options])](https://github.com/yujiosaka/headless-chrome-crawler#crawlerqueueoptions)
+- Support `extraHeaders` for [crawler.queue([options])](https://github.com/yujiosaka/headless-chrome-crawler#crawlerqueueoptions)'s options
 - Add comment in [JSDoc](http://usejsdoc.org) style
 
 ### Changed
 
 - Public API to launch a browser has changed. Now you can launch browser by [HCCrawler.launch([options])](https://github.com/yujiosaka/headless-chrome-crawler#hccrawlerlaunchoptions)
-- Rename `shouldRequest` to `preRequest` option for [crawler.queue([options])](https://github.com/yujiosaka/headless-chrome-crawler#crawlerqueueoptions)
-- Refactor by separating HCCrawler and Crawler classes
+- Rename `shouldRequest` to `preRequest` for [crawler.queue([options])](https://github.com/yujiosaka/headless-chrome-crawler#crawlerqueueoptions)'s options
+- Refactor by separating `HCCrawler` and `Crawler` classes
 - Refactor handlers for options
 
 ## [1.0.0] - 2017-12-05

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ HCCrawler.launch({
 const HCCrawler = require('headless-chrome-crawler');
 const RedisCache = require('headless-chrome-crawler/cache/redis');
 
-const cache = new SessionRedis({ host: '127.0.0.1', port: 6379 });
+const cache = new RedisCache({ host: '127.0.0.1', port: 6379 });
 
 function launch() {
   return HCCrawler.launch({
@@ -317,7 +317,7 @@ Its constructing options are passed to [NodeRedis's redis.createClient([options]
 const HCCrawler = require('headless-chrome-crawler');
 const RedisCache = require('headless-chrome-crawler/cache/redis');
 
-const cache = new SessionRedis({ host: '127.0.0.1', port: 6379 });
+const cache = new RedisCache({ host: '127.0.0.1', port: 6379 });
 
 HCCrawler.launch({
   persistCache: true, // Set true so that cache won't be cleared when closing the crawler

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headless-chrome-crawler",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Headless Chrome crawler with jQuery powered by Puppeteer",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
### Changed

- Rename `ensureCacheClear` to `persistCache` for [HCCrawler.connect([options])](https://github.com/yujiosaka/headless-chrome-crawler#hccrawlerconnectoptions) and [HCCrawler.launch([options])](https://github.com/yujiosaka/headless-chrome-crawler#hccrawlerlaunchoptions)'s options