### PR TITLE
Fix require cache

### DIFF
--- a/cache/index.js
+++ b/cache/index.js
@@ -1,3 +1,0 @@
-exports.BaseCache = require('./base');
-exports.SessionCache = require('./session');
-exports.RedisCache = require('./redis');

--- a/lib/hccrawler.js
+++ b/lib/hccrawler.js
@@ -15,8 +15,8 @@ const {
   isString,
   isArray,
 } = require('lodash');
+const SessionCache = require('../cache/session');
 const { delay, generateKey, debugRequest } = require('./helper');
-const { SessionCache } = require('../cache');
 
 const PUPPETEER_CONNECT_OPTIONS = [
   'browserWSEndpoint',


### PR DESCRIPTION
- Remove `cache/index.js` since it's not recommended way of requiring