### PR TITLE
Distributed queue

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,11 +4,13 @@ module.exports = {
     'window': true,
   },
   "rules": {
-    "class-methods-use-this": 0,
     "arrow-parens": ["warn", "as-needed"],
+    "class-methods-use-this": 0,
+    "func-names": 0,
     "no-underscore-dangle": 0,
     "no-console": 0,
     "no-void": 0,
     "no-param-reassign": 0,
+    "no-bitwise": 0,
   },
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+npm-debug.log
 coverage/
 tmp/
 !tmp/.gitkeep

--- a/cache/base.js
+++ b/cache/base.js
@@ -49,6 +49,32 @@ class BaseCache {
 
   /**
    * @param {!string} key
+   * @param {!string} value
+   * @param {!number=} priority
+   * @return {!Promise}
+   */
+  enqueue() {
+    throw new Error('Enqueue is not overridden!');
+  }
+
+  /**
+   * @param {!string} key
+   * @return {!Promise}
+   */
+  dequeue() {
+    throw new Error('Dequeue is not overridden!');
+  }
+
+  /**
+   * @param {!string} key
+   * @return {!Promise<!number>}
+   */
+  size() {
+    throw new Error('Size is not overridden!');
+  }
+
+  /**
+   * @param {!string} key
    * @return {!Promise}
    */
   remove() {

--- a/examples/custom-cache.js
+++ b/examples/custom-cache.js
@@ -27,6 +27,29 @@ class FsCache extends BaseCache {
     fs.writeFileSync(this._settings.file, JSON.stringify(obj));
     return Promise.resolve();
   }
+  enqueue(key, value, priority) {
+    const obj = JSON.parse(fs.readFileSync(this._settings.file));
+    const queue = obj[key] || [];
+    const item = { value, priority };
+    queue.push(item);
+    queue.sort((a, b) => b.priority - a.priority);
+    obj[key] = queue;
+    fs.writeFileSync(this._settings.file, JSON.stringify(obj));
+    return Promise.resolve();
+  }
+  dequeue(key) {
+    const obj = JSON.parse(fs.readFileSync(this._settings.file));
+    const queue = obj[key] || [];
+    const item = queue.shift();
+    fs.writeFileSync(FILE, JSON.stringify(obj));
+    if (!item) return Promise.resolve(null);
+    return Promise.resolve(item.value);
+  }
+  size(key) {
+    const obj = JSON.parse(fs.readFileSync(this._settings.file));
+    if (!obj[key]) return Promise.resolve(0);
+    return Promise.resolve(obj[key].length);
+  }
   remove(key) {
     const obj = JSON.parse(fs.readFileSync(this._settings.file));
     delete obj[key];

--- a/examples/custom-exporter.js
+++ b/examples/custom-exporter.js
@@ -2,7 +2,7 @@ const { inspect } = require('util');
 const HCCrawler = require('headless-chrome-crawler');
 const BaseExporter = require('headless-chrome-crawler/exporter/base');
 
-const FILE = './tmp/result.json';
+const FILE = './tmp/result';
 
 // Create a new exporter by extending BaseExporter interface
 class InspectExporter extends BaseExporter {
@@ -25,7 +25,7 @@ const exporter = new InspectExporter({
   depth: 1,
 });
 
-HCCrawler.launch({ exporter })
+HCCrawler.launch({ exporter, maxDepth: 2 })
   .then(crawler => {
     crawler.queue('https://example.com/');
     crawler.onIdle()

--- a/examples/emulate-device.js
+++ b/examples/emulate-device.js
@@ -1,6 +1,7 @@
 const HCCrawler = require('headless-chrome-crawler');
 
 HCCrawler.launch({
+  url: 'https://example.com/',
   evaluatePage: (() => ({
     userAgent: window.navigator.userAgent,
   })),
@@ -9,8 +10,8 @@ HCCrawler.launch({
   }),
 })
   .then(crawler => {
-    crawler.queue({ url: 'https://example.com/', device: 'Nexus 7' });
-    crawler.queue({ url: 'https://example.com/', userAgent: 'headless-chrome-crawler' }); // Only override userAgent
+    crawler.queue({ device: 'Nexus 7' });
+    crawler.queue({ userAgent: 'headless-chrome-crawler' }); // Only override userAgent
     crawler.onIdle()
       .then(() => crawler.close());
   });

--- a/examples/override-function.js
+++ b/examples/override-function.js
@@ -1,12 +1,11 @@
 const HCCrawler = require('headless-chrome-crawler');
 
 HCCrawler.launch({
-  // Global functions won't be called
   evaluatePage: (() => {
-    throw new Error('Evaluate page function is not overriden!');
+    throw new Error("Global functions won't be called");
   }),
-  onSuccess: (() => {
-    throw new Error('On sucess function is not overriden!');
+  onSuccess: (result => {
+    console.log(`Got ${result.result.title} for ${result.options.url}.`);
   }),
 })
   .then(crawler => {
@@ -15,9 +14,6 @@ HCCrawler.launch({
       evaluatePage: (() => ({
         title: $('title').text(),
       })),
-      onSuccess: (result => {
-        console.log(`Got ${result.result.title} for ${result.options.url}.`);
-      }),
     });
     crawler.onIdle()
       .then(() => crawler.close());

--- a/examples/pause-resume.js
+++ b/examples/pause-resume.js
@@ -13,7 +13,7 @@ HCCrawler.launch({
     crawler.queue('https://example.org/'); // The queue won't be requested until resumed
     crawler.onIdle()
       .then(() => {
-        // Lift the max request limit so that it doesn't right after resume called
+        // Lift the max request limit so that it doesn't become idle right after resume called
         crawler.setMaxRequest(3);
         crawler.resume();
         return crawler.onIdle();

--- a/examples/priority-queue.js
+++ b/examples/priority-queue.js
@@ -7,9 +7,8 @@ HCCrawler.launch({
   }),
 })
   .then(crawler => {
-    crawler.queue({ url: 'https://example.com/' }); // First queue will be requested first regardless of priority
-    crawler.queue({ url: 'https://example.net/', priority: 1 });
-    crawler.queue({ url: 'https://example.org/', priority: 2 }); // This queue is requested before the previous queue
+    crawler.queue({ url: 'https://example.com/', priority: 1 }); // First queue will be requested first regardless of priority
+    crawler.queue({ url: 'https://example.net/', priority: 2 }); // This queue is requested before the previous queue
     crawler.onIdle()
       .then(() => crawler.close());
   });

--- a/lib/async-events.js
+++ b/lib/async-events.js
@@ -1,0 +1,18 @@
+const EventEmitter = require('events');
+
+class AsyncEventEmitter extends EventEmitter {
+  /**
+   * @param {!string} event
+   * @param {...*} args
+   * @param {!Promise}
+   */
+  emit(event, ...args) {
+    const promises = [];
+    this.listeners(event).forEach(listener => {
+      promises.push(listener(...args));
+    });
+    return Promise.all(promises);
+  }
+}
+
+module.exports = AsyncEventEmitter;

--- a/lib/hccrawler.js
+++ b/lib/hccrawler.js
@@ -6,14 +6,12 @@ const {
   extend,
   each,
   includes,
-  noop,
   some,
   endsWith,
   isString,
   isArray,
 } = require('lodash');
 const request = require('request-promise');
-const PQueue = require('p-queue');
 const robotsParser = require('robots-parser');
 const Puppeteer = require('puppeteer');
 const devices = require('puppeteer/DeviceDescriptors');
@@ -23,14 +21,15 @@ const {
   getRobotsUrl,
   tracePublicAPI,
 } = require('./helper');
+const PriorityQueue = require('./priority-queue');
 const Crawler = require('./crawler');
 const SessionCache = require('../cache/session');
 
-const PUPPETEER_CONNECT_OPTIONS = [
+const CONNECT_OPTIONS = [
   'browserWSEndpoint',
   'ignoreHTTPSErrors',
 ];
-const PUPPETEER_LAUNCH_OPTIONS = [
+const LAUNCH_OPTIONS = [
   'ignoreHTTPSErrors',
   'headless',
   'executablePath',
@@ -45,20 +44,23 @@ const PUPPETEER_LAUNCH_OPTIONS = [
   'env',
   'devtools',
 ];
-const CONSTRUCTOR_OPTIONS = [
+const CONSTRUCTOR_OPTIONS = CONNECT_OPTIONS.concat(LAUNCH_OPTIONS).concat([
   'maxConcurrency',
   'maxRequest',
   'cache',
   'exporter',
   'persistCache',
-];
+  'preRequest',
+  'onSuccess',
+  'onError',
+]);
 const RESPONSE_FIELDS = [
   'ok',
   'url',
   'status',
   'headers',
 ];
-const ROBOTS_TXT_ERROR = 'error';
+const EMPTY_TXT = '';
 
 const deviceNames = Object.keys(devices);
 
@@ -68,8 +70,8 @@ class HCCrawler extends EventEmitter {
    * @return {!Promise}
    */
   static connect(options) {
-    return Puppeteer.connect(pick(options, PUPPETEER_CONNECT_OPTIONS))
-      .then(browser => new HCCrawler(browser, omit(options, PUPPETEER_CONNECT_OPTIONS)))
+    return Puppeteer.connect(pick(options, CONNECT_OPTIONS))
+      .then(browser => new HCCrawler(browser, omit(options, CONNECT_OPTIONS)))
       .then(crawler => crawler.init().then(() => crawler));
   }
 
@@ -78,8 +80,8 @@ class HCCrawler extends EventEmitter {
    * @return {!Promise}
    */
   static launch(options) {
-    return Puppeteer.launch(pick(options, PUPPETEER_LAUNCH_OPTIONS))
-      .then(browser => new HCCrawler(browser, omit(options, PUPPETEER_LAUNCH_OPTIONS)))
+    return Puppeteer.launch(pick(options, LAUNCH_OPTIONS))
+      .then(browser => new HCCrawler(browser, omit(options, LAUNCH_OPTIONS)))
       .then(crawler => crawler.init().then(() => crawler));
   }
 
@@ -101,7 +103,7 @@ class HCCrawler extends EventEmitter {
       maxDepth: 1,
       maxConcurrency: 10,
       maxRequest: 0,
-      priority: 1,
+      priority: 0,
       delay: 0,
       retryCount: 3,
       retryDelay: 10000,
@@ -112,18 +114,30 @@ class HCCrawler extends EventEmitter {
       screenshot: null,
     }, options);
     this._cache = options.cache || new SessionCache();
+    this._queue = new PriorityQueue({
+      maxConcurrency: this._options.maxConcurrency,
+      cache: this._cache,
+    });
     this._exporter = options.exporter || null;
-    this._pQueue = new PQueue({ concurrency: this._options.maxConcurrency });
     this._requestedCount = 0;
+    this._preRequest = options.preRequest || null;
+    this._onSuccess = options.onSuccess || null;
+    this._onError = options.onError || null;
     this._exportHeader();
-    this._browser.on('disconnected', () => void this.emit(HCCrawler.Events.Disconnected));
+    this._queue.on('pull', (...args) => this._onPull(...args));
+    this._browser.on('disconnected', () => {
+      this.emit(HCCrawler.Events.Disconnected);
+    });
   }
 
   /**
    * @return {!Promise}
    */
   init() {
-    return this._cache.init();
+    return this._cache.init()
+      .then(() => {
+        this._queue.init();
+      });
   }
 
   /**
@@ -131,14 +145,16 @@ class HCCrawler extends EventEmitter {
    */
   queue(options) {
     each(isArray(options) ? options : [options], _options => {
-      let mergedOptions = isString(_options) ? { url: _options } : _options;
-      mergedOptions = extend({}, this._options, mergedOptions);
+      const queueOptions = isString(_options) ? { url: _options } : _options;
+      each(CONSTRUCTOR_OPTIONS, option => {
+        if (queueOptions[option]) throw new Error(`Overriding ${option} is not allowed!`);
+      });
+      const mergedOptions = extend({}, this._options, queueOptions);
+      if (mergedOptions.evaluatePage) mergedOptions.evaluatePage = `(${mergedOptions.evaluatePage})()`;
       if (!mergedOptions.url) throw new Error('Url must be defined!');
       if (mergedOptions.device && !includes(deviceNames, mergedOptions.device)) throw new Error('Specified device is not supported!');
       if (mergedOptions.delay > 0 && mergedOptions.maxConcurrency !== 1) throw new Error('Max concurrency must be 1 when delay is set!');
-      this._pQueue.add(() => this._request(omit(mergedOptions, CONSTRUCTOR_OPTIONS)), {
-        priority: mergedOptions.priority,
-      });
+      this._queue.push(omit(mergedOptions, CONSTRUCTOR_OPTIONS), mergedOptions.priority);
     });
   }
 
@@ -165,14 +181,14 @@ class HCCrawler extends EventEmitter {
   }
 
   /**
-   * @return {!Promise}
+   * @return {!Promise<!string>}
    */
   version() {
     return this._browser.version();
   }
 
   /**
-   * @return {!Promise}
+   * @return {!Promise<!string>}
    */
   wsEndpoint() {
     return this._browser.wsEndpoint();
@@ -182,7 +198,7 @@ class HCCrawler extends EventEmitter {
    * @return {!Promise}
    */
   onIdle() {
-    return this._pQueue.onIdle();
+    return this._queue.onIdle();
   }
 
   /**
@@ -193,11 +209,11 @@ class HCCrawler extends EventEmitter {
   }
 
   pause() {
-    this._pQueue.pause();
+    this._queue.pause();
   }
 
   resume() {
-    this._pQueue.start();
+    this._queue.resume();
   }
 
   /**
@@ -211,21 +227,21 @@ class HCCrawler extends EventEmitter {
    * @return {!bolean}
    */
   isPaused() {
-    return this._pQueue.isPaused;
+    return this._queue.isPaused();
   }
 
   /**
-   * @return {!number}
+   * @return {!Promise<!number>}
    */
   queueSize() {
-    return this._pQueue.size;
+    return this._queue.size();
   }
 
   /**
    * @return {!number}
    */
   pendingQueueSize() {
-    return this._pQueue.pending;
+    return this._queue.pending();
   }
 
   /**
@@ -238,54 +254,66 @@ class HCCrawler extends EventEmitter {
   /**
    * @param {!Object} options
    * @param {!number=} depth
-   * @param {!number=} retryCount
+   * @return {!Promise}
    * @private
    */
-  _request(options, depth = 1, retryCount = 0) {
-    if (retryCount === 0) this.emit(HCCrawler.Events.RequestStarted, options);
+  _onPull(options, depth = 1) {
     return Promise.all([
       this._checkExists(options),
       this._checkAllowedRobots(options),
       this._checkAllowedDomains(options),
-      this._preRequest(options),
+      this._shouldRequest(options),
     ])
       .then(([exists, allowedRobot, allowedDomain, shouldRequest]) => {
         if (exists || !allowedRobot || !allowedDomain || !shouldRequest) {
           this.emit(HCCrawler.Events.RequestSkipped, options);
           return Promise.resolve();
         }
-        return this._newPage(options)
-          .then(crawler => (
-            crawler.crawl()
-              .then(res => {
-                this.emit(HCCrawler.Events.RequestFinished, options);
-                res.response = pick(res.response, RESPONSE_FIELDS);
-                res.options = options;
-                const onSuccess = options.onSuccess || noop;
-                return Promise.resolve(onSuccess(res))
-                  .then(() => void this._exportLine(res))
-                  .then(() => void this._followLinks(res.links, options, depth))
-                  .then(() => void this._checkRequestCount())
-                  .then(() => crawler.close())
-                  .then(() => delay(options.delay));
-              })
-              .catch(error => {
-                this.emit(HCCrawler.Events.RequestFailed, error);
-                if (retryCount >= options.retryCount) throw error;
-                return crawler.close()
-                  .then(() => delay(options.retryDelay))
-                  .then(() => this._removeExists(options))
-                  .then(() => this._request(options, depth, retryCount + 1));
-              })
-              .catch(error => {
-                const onError = options.onError || noop;
-                return Promise.resolve(onError(error))
-                  .then(() => this._checkRequestCount())
-                  .then(() => crawler.close())
-                  .then(() => delay(options.delay));
-              })
-          ));
+        return this._request(options, depth);
       });
+  }
+
+  /**
+   * @param {!Object} options
+   * @param {!number} depth
+   * @param {!number=} retryCount
+   * @return {!Promise}
+   * @private
+   */
+  _request(options, depth, retryCount = 0) {
+    this.emit(HCCrawler.Events.RequestStarted, options);
+    return this._newPage(options)
+      .then(crawler => (
+        crawler.crawl()
+          .then(res => {
+            res.response = pick(res.response, RESPONSE_FIELDS);
+            res.options = options;
+            this.emit(HCCrawler.Events.RequestFinished, res);
+            return this._success(res)
+              .then(() => {
+                this._exportLine(res);
+                this._followLinks(res.links, options, depth);
+                this._checkRequestCount();
+              })
+              .then(() => crawler.close())
+              .then(() => delay(options.delay));
+          })
+          .catch(error => {
+            if (retryCount >= options.retryCount) throw error;
+            this.emit(HCCrawler.Events.RequestRetried, options);
+            return this._removeExists(options)
+              .then(() => crawler.close())
+              .then(() => delay(options.retryDelay))
+              .then(() => this._request(options, depth, retryCount + 1));
+          })
+          .catch(error => {
+            this.emit(HCCrawler.Events.RequestFailed, error);
+            return this._error(error)
+              .then(() => void this._checkRequestCount())
+              .then(() => crawler.close())
+              .then(() => delay(options.delay));
+          })
+      ));
   }
 
   /**
@@ -297,14 +325,13 @@ class HCCrawler extends EventEmitter {
     if (!options.obeyRobotsTxt) return Promise.resolve(true);
     const robotsUrl = getRobotsUrl(options.url);
     return this._getRobotsTxt(robotsUrl)
-      .then(robotsTxt => {
-        if (!robotsTxt) return true;
-        return this._getUserAgent(options)
+      .then(robotsTxt => (
+        this._getUserAgent(options)
           .then(userAgent => {
             const robot = robotsParser(robotsUrl, robotsTxt);
             return robot.isAllowed(options.url, userAgent);
-          });
-      });
+          })
+      ));
   }
 
   /**
@@ -315,13 +342,16 @@ class HCCrawler extends EventEmitter {
   _getRobotsTxt(url) {
     return this._cache.get(url)
       .then(cachedTxt => {
-        if (cachedTxt === ROBOTS_TXT_ERROR) return null;
-        if (cachedTxt) return cachedTxt;
+        if (isString(cachedTxt)) return cachedTxt;
         return request(url)
-          .then(txt => this._cache.set(url, txt).then(() => txt))
+          .then(txt => (
+            this._cache.set(url, txt)
+              .then(() => txt)
+          ))
           .catch(error => {
             this.emit(HCCrawler.Events.RobotsTxtRequestFailed, error);
-            return this._cache.set(url, ROBOTS_TXT_ERROR).then(() => null);
+            return this._cache.set(url, EMPTY_TXT)
+              .then(() => EMPTY_TXT);
           });
       });
   }
@@ -379,9 +409,29 @@ class HCCrawler extends EventEmitter {
    * @return {!Promise<?boolean>}
    * @private
    */
-  _preRequest(options) {
-    if (!options.preRequest) return Promise.resolve(true);
-    return Promise.resolve(options.preRequest(options));
+  _shouldRequest(options) {
+    if (!this._preRequest) return Promise.resolve(true);
+    return Promise.resolve(this._preRequest(options));
+  }
+
+  /**
+   * @param {!Object} result
+   * @return {!Promise<?boolean>}
+   * @private
+   */
+  _success(result) {
+    if (!this._onSuccess) return Promise.resolve();
+    return Promise.resolve(this._onSuccess(result));
+  }
+
+  /**
+   * @param {!Error} error
+   * @return {!Promise<?boolean>}
+   * @private
+   */
+  _error(error) {
+    if (!this._onError) return Promise.resolve();
+    return Promise.resolve(this._onError(error));
   }
 
   /**
@@ -407,9 +457,7 @@ class HCCrawler extends EventEmitter {
     }
     each(links, link => {
       const _options = extend({}, options, { url: link });
-      this._pQueue.add(() => this._request(_options, depth + 1), {
-        priority: _options.priority,
-      });
+      this._queue.push(_options, depth + 1, _options.priority);
     });
   }
 
@@ -478,6 +526,7 @@ HCCrawler.Events = {
   RequestStarted: 'requeststarted',
   RequestSkipped: 'requestskipped',
   RequestFinished: 'requestfinished',
+  RequestRetried: 'requestretried',
   RequestFailed: 'requestfailed',
   RobotsTxtRequestFailed: 'robotstxtrequestfailed',
   MaxDepthReached: 'maxdepthreached',

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -104,6 +104,23 @@ class Helper {
     return format({ protocol, host, pathname: '/robots.txt' });
   }
 
+  // Ported from http://en.cppreference.com/w/cpp/algorithm/lower_bound
+  static lowerBound(array, value, comp) {
+    let first = 0;
+    let count = array.length;
+    while (count > 0) {
+      const step = (count / 2) | 0;
+      const it = first + step;
+      if (comp(array[it], value) <= 0) {
+        first += it;
+        count -= step + 1;
+      } else {
+        count = step;
+      }
+    }
+    return first;
+  }
+
   /**
    * @param {!Object} classType
    */

--- a/lib/priority-queue.js
+++ b/lib/priority-queue.js
@@ -1,0 +1,117 @@
+const AsyncEventEmitter = require('./async-events');
+const { noop } = require('lodash');
+const { tracePublicAPI } = require('./helper');
+
+const KEY = 'queue';
+const INTERVAL = 200;
+
+class PriorityQueue extends AsyncEventEmitter {
+  /**
+   * @param {!Object} options
+   */
+  constructor(options) {
+    super();
+    this._cache = options.cache;
+    this._maxConcurrency = options.maxConcurrency || Infinity;
+    this._isPaused = false;
+    this._pendingCount = 0;
+    this._resolveIdle = noop;
+  }
+
+  init() {
+    this._watch();
+  }
+
+  /**
+   * @param {...*} args
+   */
+  push(...args) {
+    const priority = args.pop();
+    this._cache.enqueue(KEY, args, priority)
+      .then(() => void this._pull());
+  }
+
+  pause() {
+    this._isPaused = true;
+    this._idle();
+  }
+
+  resume() {
+    if (!this._isPaused) return;
+    this._isPaused = false;
+    this._pull();
+    this._watch();
+  }
+
+  /**
+   * @return {!boolean}
+   */
+  isPaused() {
+    return this._isPaused;
+  }
+
+  /**
+   * @return {!number}
+   */
+  pending() {
+    return this._pendingCount;
+  }
+
+  /**
+   * @return {!Promise<!number>}
+   */
+  size() {
+    return this._cache.size(KEY);
+  }
+
+  /**
+   * @return {!Promise}
+   */
+  onIdle() {
+    return new Promise(resolve => {
+      this._resolveIdle = resolve;
+    });
+  }
+
+  /**
+   * @private
+   */
+  _pull() {
+    if (this._isPaused) return;
+    if (this._pendingCount >= this._maxConcurrency) return;
+    this._pendingCount += 1;
+    this._cache.dequeue(KEY)
+      .then(args => {
+        if (!args) {
+          this._pendingCount -= 1;
+          if (this._pendingCount === 0) this._idle();
+          return;
+        }
+        this.emit('pull', ...args)
+          .then(() => {
+            this._pendingCount -= 1;
+            this._pull();
+          });
+      });
+  }
+
+  /**
+   * @private
+   */
+  _watch() {
+    clearInterval(this._interval);
+    this._interval = setInterval(() => { this._pull(); }, INTERVAL);
+  }
+
+  /**
+   * @private
+   */
+  _idle() {
+    clearInterval(this._interval);
+    this._resolveIdle();
+  }
+}
+
+tracePublicAPI(PriorityQueue);
+
+module.exports = PriorityQueue;

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "debug": "3.1.0",
     "jquery": "3.2.1",
     "lodash": "4.17.4",
-    "p-queue": "2.3.0",
     "puppeteer": "0.13.0",
     "redis": "2.8.0",
     "request": "2.83.0",

--- a/test/async-events.test.js
+++ b/test/async-events.test.js
@@ -1,0 +1,71 @@
+const assert = require('assert');
+const AsyncEventEmitter = require('../lib/async-events');
+const { delay } = require('../lib/helper');
+
+describe('AsyncEventEmitter', () => {
+  let eventEmitter;
+
+  beforeEach(() => {
+    eventEmitter = new AsyncEventEmitter();
+  });
+
+  it('listens to an event', () => {
+    let actual = 0;
+    const expected = 1;
+    eventEmitter.on('success', () => { actual += 1; });
+    eventEmitter.emit('success');
+    assert.equal(actual, expected);
+  });
+
+  it('listens to an event emitted multiple times', () => {
+    let actual = 0;
+    const expected = 2;
+    eventEmitter.on('success', () => { actual += 1; });
+    eventEmitter.emit('success');
+    eventEmitter.emit('success');
+    assert.equal(actual, expected);
+  });
+
+  it('listens multiple times to an event', () => {
+    let actual = 0;
+    const expected = 3;
+    eventEmitter.on('success', () => { actual += 1; });
+    eventEmitter.on('success', () => { actual += 2; });
+    eventEmitter.emit('success');
+    assert.equal(actual, expected);
+  });
+
+  it('listens to an event with single argument', () => {
+    let actual;
+    const expected = new Error('Url must be defined!');
+    eventEmitter.on('error', error => { actual = error; });
+    eventEmitter.emit('error', expected);
+    assert.equal(actual, expected);
+  });
+
+  it('listens to an event with multiple arguments', () => {
+    let actual;
+    const expected = 1;
+    eventEmitter.on('pull', (options, depth) => { actual = depth; });
+    eventEmitter.emit('pull', { url: 'http://example.com/' }, 1);
+    assert.equal(actual, expected);
+  });
+
+  it('listens to an async event', () => {
+    let actual = 0;
+    const expected = 0;
+    eventEmitter.on('success', () => delay(100).then(() => { actual += 1; }));
+    eventEmitter.emit('success');
+    assert.equal(actual, expected);
+  });
+
+  it('waits until resolving async event', () => {
+    let actual = 0;
+    const expected = 1;
+    eventEmitter.on('success', () => delay(100).then(() => { actual += 1; }));
+    return eventEmitter.emit('success')
+      .then(() => {
+        assert.equal(actual, expected);
+      });
+  });
+});

--- a/test/helper.test.js
+++ b/test/helper.test.js
@@ -8,6 +8,7 @@ const {
   resolveUrl,
   escapeQuotes,
   getRobotsUrl,
+  lowerBound,
   stringifyArgument,
   debugConsole,
   debugDialog,
@@ -172,6 +173,44 @@ describe('Helper', () => {
     it('locates robots.txt for non-standard https URL', () => {
       const actual = getRobotsUrl('https://example.com:8432/');
       const expected = 'https://example.com:8432/robots.txt';
+      assert.equal(actual, expected);
+    });
+  });
+
+  describe('Helper.lowerBound', () => {
+    it('returns the first index for positive values', () => {
+      const queue = [
+        { priority: 4 },
+        { priority: 3 },
+        { priority: 1 },
+      ];
+      const item = { priority: 2 };
+      const actual = lowerBound(queue, item, (a, b) => b.priority - a.priority);
+      const expected = 2;
+      assert.equal(actual, expected);
+    });
+
+    it('returns the first index for negative values', () => {
+      const queue = [
+        { priority: -1 },
+        { priority: -2 },
+        { priority: -4 },
+      ];
+      const item = { priority: -3 };
+      const actual = lowerBound(queue, item, (a, b) => b.priority - a.priority);
+      const expected = 2;
+      assert.equal(actual, expected);
+    });
+
+    it('returns the first index for mixed values', () => {
+      const queue = [
+        { priority: 1 },
+        { priority: 0 },
+        { priority: -2 },
+      ];
+      const item = { priority: -1 };
+      const actual = lowerBound(queue, item, (a, b) => b.priority - a.priority);
+      const expected = 2;
       assert.equal(actual, expected);
     });
   });

--- a/test/priority-queue.test.js
+++ b/test/priority-queue.test.js
@@ -1,0 +1,175 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const { delay } = require('../lib/helper');
+const PriorityQueue = require('../lib/priority-queue');
+const SessionCache = require('../cache/session');
+const RedisCache = require('../cache/redis');
+
+describe('PriorityQueue', () => {
+  let queue;
+  let onPull;
+  let cache;
+
+  beforeEach(() => {
+    onPull = sinon.spy();
+  });
+
+  afterEach(() => (
+    cache.clear()
+      .then(() => cache.close())
+  ));
+
+  function testSuite() {
+    it('pulls without argument', () => {
+      queue.push(0);
+      return queue.onIdle()
+        .then(() => {
+          assert.equal(onPull.callCount, 1);
+        });
+    });
+
+    it('pulls with a number', () => {
+      queue.push(1, 0);
+      return queue.onIdle()
+        .then(() => {
+          assert.equal(onPull.callCount, 1);
+          assert.ok(onPull.calledWith(1));
+        });
+    });
+
+    it('pulls with a string', () => {
+      queue.push('http://example.com/', 0);
+      return queue.onIdle()
+        .then(() => {
+          assert.equal(onPull.callCount, 1);
+          assert.ok(onPull.calledWith('http://example.com/'));
+        });
+    });
+
+    it('pulls with an object', () => {
+      queue.push({ url: 'http://example.com' }, 0);
+      return queue.onIdle()
+        .then(() => {
+          assert.equal(onPull.callCount, 1);
+          assert.ok(onPull.calledWith({ url: 'http://example.com' }));
+        });
+    });
+
+    it('pulls with multiple arguments', () => {
+      queue.push({ url: 'http://example.com/' }, 1, 0);
+      return queue.onIdle()
+        .then(() => {
+          assert.equal(onPull.callCount, 1);
+          assert.ok(onPull.calledWith({ url: 'http://example.com/' }, 1));
+        });
+    });
+
+    it('obeys priority order', () => {
+      queue.push({ url: 'http://example.com/' }, 1);
+      queue.push({ url: 'http://example.net/' }, 2);
+      return queue.onIdle()
+        .then(() => {
+          assert.equal(onPull.callCount, 2);
+          assert.ok(onPull.firstCall.calledWith({ url: 'http://example.net/' }));
+          assert.ok(onPull.secondCall.calledWith({ url: 'http://example.com/' }));
+        });
+    });
+
+    it('pauses and resumes', () => {
+      queue.push({ url: 'http://example.com/' }, 1, 0);
+      return Promise.all([
+        queue.onIdle(),
+        queue.pause(),
+      ])
+        .then(() => {
+          assert.equal(onPull.callCount, 0);
+          assert.equal(queue.isPaused(), true);
+          assert.equal(queue.pending(), 0);
+          return queue.size();
+        })
+        .then(size => {
+          assert.equal(size, 1);
+          queue.resume();
+          return queue.onIdle();
+        })
+        .then(() => {
+          assert.equal(onPull.callCount, 1);
+        });
+    });
+  }
+
+  context('when constructed with SessionCache', () => {
+    beforeEach(() => {
+      cache = new SessionCache();
+      return cache.init()
+        .then(() => {
+          queue = new PriorityQueue({
+            maxConcurrency: 1,
+            cache,
+          });
+          queue.on('pull', onPull);
+        });
+    });
+
+    testSuite();
+  });
+
+  context('when constructed with RedisCache', () => {
+    context('when queue is not registered', () => {
+      beforeEach(() => {
+        cache = new RedisCache();
+        return cache.init()
+          .then(() => {
+            queue = new PriorityQueue({
+              maxConcurrency: 1,
+              cache,
+            });
+            queue.on('pull', onPull);
+          });
+      });
+
+      testSuite();
+    });
+
+    context('when queue is already registered', () => {
+      beforeEach(() => {
+        cache = new RedisCache();
+        return cache.init()
+          .then(() => {
+            queue = new PriorityQueue({ cache });
+            queue.push({ url: 'http://example.com/' }, 1, 0);
+            return Promise.all([
+              queue.onIdle(),
+              queue.pause(),
+            ]);
+          })
+          .then(() => {
+            queue = new PriorityQueue({ cache });
+            queue.on('pull', onPull);
+          });
+      });
+
+      context('when the queue is initialized', () => {
+        beforeEach(() => {
+          queue.init();
+        });
+        it('pulls from the registered queue', () => (
+          queue.onIdle()
+            .then(() => {
+              assert.equal(onPull.callCount, 1);
+              assert.ok(onPull.calledWith({ url: 'http://example.com/' }, 1));
+            })
+        ));
+      });
+
+      context('when the queue is not initialized', () => {
+        it('does not pull from the registered', () => (
+          delay(500)
+            .then(() => {
+              assert.equal(onPull.callCount, 0);
+            })
+        ));
+      });
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -510,9 +510,9 @@ eslint-visitor-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
 
-eslint@4.14.0:
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.14.0.tgz#96609768d1dd23304faba2d94b7fefe5a5447a82"
+eslint@4.15.0:
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.15.0.tgz#89ab38c12713eec3d13afac14e4a89e75ef08145"
   dependencies:
     ajv "^5.3.0"
     babel-code-frame "^6.22.0"
@@ -1124,9 +1124,9 @@ mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
-mocha@4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-4.0.1.tgz#0aee5a95cf69a4618820f5e51fa31717117daf1b"
+mocha@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-4.1.0.tgz#7d86cfbcf35cb829e2754c32e17355ec05338794"
   dependencies:
     browser-stdout "1.3.0"
     commander "2.11.0"
@@ -1231,10 +1231,6 @@ p-locate@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
   dependencies:
     p-limit "^1.1.0"
-
-p-queue@2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-2.3.0.tgz#65d55e71bc1500fc413122da98ae457ff8a7c038"
 
 parse-json@^2.2.0:
   version "2.2.0"
@@ -1612,9 +1608,9 @@ signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
-sinon@4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-4.1.3.tgz#fc599eda47ed9f1a694ce774b94ab44260bd7ac5"
+sinon@4.1.4:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-4.1.4.tgz#36bb237bae38ddf9cc92dcc1b16c51e7785bbc9c"
   dependencies:
     diff "^3.1.0"
     formatio "1.2.0"


### PR DESCRIPTION
- `preRequest`, `onSuccess` and `onError` cannot be overridden from now on
- `requestfailed` event is now fired when all retries fails
- `requestretried` event is fired when request retries

Fixes: https://github.com/yujiosaka/headless-chrome-crawler/issues/56  
  