### PR TITLE
Update puppeteer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # headless-chrome-crawler [![npm](https://badge.fury.io/js/headless-chrome-crawler.svg)](https://www.npmjs.com/package/headless-chrome-crawler) [![build](https://circleci.com/gh/yujiosaka/headless-chrome-crawler/tree/master.svg?style=shield&circle-token=ba45f930aed7057b79f2ac09df6be3e1b8ee954b)](https://circleci.com/gh/yujiosaka/headless-chrome-crawler/tree/master) [![Greenkeeper badge](https://badges.greenkeeper.io/yujiosaka/headless-chrome-crawler.svg)](https://greenkeeper.io/)
-Headless Chrome crawls with [jQuery](https://jquery.com) support, powered by [Puppeteer](https://github.com/GoogleChrome/puppeteer)
+Headless Chrome crawls with [jQuery](https://jquery.com) support
 
 ## Features
 
@@ -32,7 +32,7 @@ yarn add headless-chrome-crawler
 
 ### Usage
 
-The basic API of headless-chrome-crawler is inspired by that of [node-crawler](https://github.com/bda-research/node-crawler), so the API design is somewhat similar but not exactly compatible.
+The basic API of headless-chrome-crawler is inspired by that of [node-crawler](https://github.com/bda-research/node-crawler).
 
 ```js
 const HCCrawler = require('headless-chrome-crawler');
@@ -54,18 +54,12 @@ HCCrawler.launch({
     crawler.queue(['https://example.net/', 'https://example.org/']);
     // Queue a request with custom options
     crawler.queue({
-      url: 'https://www.example.com/',
-      // Disable jQuery only for this request
-      jQuery: false,
-      // Override an already defined evaluatePage option
-      evaluatePage: (() => ({
-        title: document.title,
-      })),
+      url: 'https://example.com/',
       // Emulate a tablet device
       device: 'Nexus 7',
       // Enable screenshot by passing options
       screenshot: {
-        path: './tmp/www-example-com.png'
+        path: './tmp/example-com.png'
       },
     });
     crawler.onIdle() // Resolved when no queue is left
@@ -76,7 +70,6 @@ HCCrawler.launch({
 ## Examples
 
 * [Priority queue for crawling efficiency](https://github.com/yujiosaka/headless-chrome-crawler/blob/master/examples/priority-queue.js)
-* [Pause at the max request and resume at any time](https://github.com/yujiosaka/headless-chrome-crawler/blob/master/examples/pause-resume.js)
 * [Emulate device and user agent](https://github.com/yujiosaka/headless-chrome-crawler/blob/master/examples/emulate-device.js)
 * [Redis cache to skip duplicate requests](https://github.com/yujiosaka/headless-chrome-crawler/blob/master/examples/redis-cache.js)
 * [Export a CSV file for crawled results](https://github.com/yujiosaka/headless-chrome-crawler/blob/master/examples/csv-exporter.js)
@@ -96,6 +89,7 @@ NODE_PATH=../ node examples/priority-queue.js
   * [HCCrawler.connect([options])](#hccrawlerconnectoptions)
   * [HCCrawler.launch([options])](#hccrawlerlaunchoptions)
   * [HCCrawler.executablePath()](#hccrawlerexecutablepath)
+  * [HCCrawler.defaultArgs()](#hccrawlerdefaultargs)
   * [crawler.queue([options])](#crawlerqueueoptions)
   * [crawler.setMaxRequest(maxRequest)](#crawlersetmaxrequestmaxrequest)
   * [crawler.pause()](#crawlerpause)
@@ -127,7 +121,7 @@ NODE_PATH=../ node examples/priority-queue.js
 
 ### class: HCCrawler
 
-HCCrawler provides methods to launch or connect to a HeadlessChrome/Chromium.
+HCCrawler provides methods to launch or connect to a Chromium instance.
 
 ```js
 const HCCrawler = require('headless-chrome-crawler');
@@ -170,7 +164,7 @@ HCCrawler.launch({
       * `links` <[Array]> List of links found in the requested page.
   * `onError(error)` <[Function]> Function to be called when request fails.
     * `error` <[Error]> Error object.
-* returns: <Promise<HCCrawler>> Promise which resolves to HCCrawler instance.
+* returns: <[Promise]<[HCCrawler]>> Promise which resolves to HCCrawler instance.
 
 This method connects to an existing Chromium instance. The following options are passed to [puppeteer.connect()](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteerconnectoptions).
 
@@ -209,12 +203,12 @@ url, allowedDomains, timeout, priority, delay, retryCount, retryDelay, jQuery, d
       * `links` <[Array]> List of links found in the requested page.
   * `onError(error)` <[Function]> Function to be called when request fails.
     * `error` <[Error]> Error object.
-* returns: <Promise<HCCrawler>> Promise which resolves to HCCrawler instance.
+* returns: <[Promise]<[HCCrawler]>> Promise which resolves to HCCrawler instance.
 
 The method launches a HeadlessChrome/Chromium instance. The following options are passed to [puppeteer.launch()](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteerlaunchoptions).
 
 ```
-ignoreHTTPSErrors, headless, executablePath, slowMo, args, handleSIGINT, handleSIGTERM, handleSIGHUP, timeout, dumpio, userDataDir, env, devtools
+ignoreHTTPSErrors, headless, executablePath, slowMo, args, ignoreDefaultArgs, handleSIGINT, handleSIGTERM, handleSIGHUP, timeout, dumpio, userDataDir, env, devtools
 ```
 
 Also, the following options can be set as default values when [crawler.queue()](#crawlerqueueoptions) are executed.
@@ -227,9 +221,13 @@ url, allowedDomains, timeout, priority, delay, retryCount, retryDelay, jQuery, d
 
 #### HCCrawler.executablePath()
 
-* returns: <string> An expected path to find bundled Chromium.
+* returns: <[string]> An expected path to find bundled Chromium.
 
 See [puppeteer.executablePath()](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteerexecutablepath) for more details.
+
+#### HCCrawler.defaultArgs()
+
+* returns: <[Array]<[string]>> The default flags that Chromium will be launched with.
 
 #### crawler.queue([options])
 
@@ -239,7 +237,7 @@ See [puppeteer.executablePath()](https://github.com/GoogleChrome/puppeteer/blob/
   * `priority` <[number]> Basic priority of queues, defaults to `1`. Priority with larger number is preferred.
   * `skipDuplicates` <[boolean]> Whether to skip duplicate requests, default to `null`. The request is considered to be the same if `url`, `userAgent`, `device` and `extraHeaders` are strictly the same.
   * `obeyRobotsTxt` <[boolean]> Whether to obey [robots.txt](https://developers.google.com/search/reference/robots_txt), default to `true`.
-  * `allowedDomains` <[Array<string>]> List of domains allowed to request. `www.example.com` will be allowed if `example.com` is listed.
+  * `allowedDomains` <[Array]<[string]>> List of domains allowed to request. `www.example.com` will be allowed if `example.com` is listed.
   * `delay` <[number]> Number of milliseconds after each request, defaults to `0`. When delay is set, `maxConcurrency` option must be `1`.
   * `retryCount` <[number]> Number of limit when retry fails, defaults to `3`.
   * `retryDelay` <[number]> Number of milliseconds after each retry fails, defaults to `10000`.
@@ -294,13 +292,13 @@ See [Puppeteer's browser.disconnect()](https://github.com/GoogleChrome/puppeteer
 
 #### crawler.version()
 
-* returns: <[Promise]> Promise resolved with HeadlessChrome/Chromium version.
+* returns: <[Promise]<[string]>> Promise resolved with HeadlessChrome/Chromium version.
 
 See [Puppeteer's browser.version()](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#browserversion) for more details.
 
 #### crawler.wsEndpoint()
 
-* returns: <[Promise]> Promise resolved with websocket url.
+* returns: <[Promise]<[string]>> Promise resolved with websocket url.
 
 See [Puppeteer's browser.wsEndpoint()](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#browserwsendpoint) for more details.
 
@@ -412,7 +410,7 @@ See [here](https://github.com/yujiosaka/headless-chrome-crawler/blob/master/exam
 
 * `options` <[Object]>
   * `file` <[string]> File path to export output.
-  * `fields` <[Array<string>]> List of fields to be used for columns. This option is also used for the headers.
+  * `fields` <[Array]<[string]>> List of fields to be used for columns. This option is also used for the headers.
   * `separator` <string> Character to separate columns.
 
 ```js
@@ -435,7 +433,7 @@ HCCrawler.launch({ exporter })
 
 * `options` <[Object]>
   * `file` <[string]> File path to export output.
-  * `fields` <[Array<string>]> List of fields to be filtered in json, defaults to `null`. Leave default not to filter fields.
+  * `fields` <[Array]<[string]>> List of fields to be filtered in json, defaults to `null`. Leave default not to filter fields.
   * `jsonReplacer` <[Function]> Function that alters the behavior of the stringification process, defaults to `null`. This is useful to sorts keys always in the same order.
 
 ```js
@@ -496,3 +494,17 @@ The static crawlers are based on simple requests to HTML files. They are general
 Dynamic crawlers based on [PhantomJS](http://phantomjs.org) and [Selenium](http://www.seleniumhq.org) work magically on such dynamic applications. However, [PhantomJS's maintainer has stepped down and recommended to switch to Headless Chrome](https://groups.google.com/forum/#!topic/phantomjs/9aI5d-LDuNE), which is fast and stable. [Selenium](http://www.seleniumhq.org) is still a well-maintained cross browser platform which runs on Chrome, Safari, IE and so on. However, crawlers do not need such cross browsers support.
 
  This crawler is dynamic and based on Headless Chrome.
+
+[Array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array "Array"
+[boolean]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type "Boolean"
+[Buffer]: https://nodejs.org/api/buffer.html#buffer_class_buffer "Buffer"
+[function]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function "Function"
+[number]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Number_type "Number"
+[Object]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object "Object"
+[Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
+[string]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type "String"
+[Serializable]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#Description "Serializable"
+[Error]: https://nodejs.org/api/errors.html#errors_class_error "Error"
+[HCCrawler]: #class-hccrawler "HCCrawler"
+[Exporter]: #baseexporter "Exporter"
+[Cache]: #basecache "Cache"

--- a/lib/hccrawler.js
+++ b/lib/hccrawler.js
@@ -93,6 +93,13 @@ class HCCrawler extends EventEmitter {
   }
 
   /**
+   * @return {!Array<!string>}
+   */
+  static defaultArgs() {
+    return Puppeteer.defaultArgs();
+  }
+
+  /**
    * @param {!Puppeteer.Browser} browser
    * @param {!Object} options
    */
@@ -362,7 +369,7 @@ class HCCrawler extends EventEmitter {
    * @private
    */
   _getUserAgent(options) {
-    return this._browser._connection.send('Browser.getVersion')
+    return this._browser.userAgent()
       .then(version => (
         options.userAgent ||
         (devices[options.device] && devices[options.device].userAgent) ||

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "headless-chrome-crawler",
   "version": "1.2.5",
-  "description": "Headless Chrome crawls with jQuery support, powered by Puppeteer",
+  "description": "Headless Chrome crawls with jQuery support",
   "main": "index.js",
   "license": "MIT",
   "author": "Yuji Isobe",
@@ -22,7 +22,7 @@
     "debug": "3.1.0",
     "jquery": "3.2.1",
     "lodash": "4.17.4",
-    "puppeteer": "0.13.0",
+    "puppeteer": "1.0.0",
     "redis": "2.8.0",
     "request": "2.83.0",
     "request-promise": "4.2.2",

--- a/test/hccrawler.test.js
+++ b/test/hccrawler.test.js
@@ -1,7 +1,7 @@
-const { unlink, readFile } = require('fs');
+const { unlink, readFile, existsSync } = require('fs');
 const assert = require('assert');
 const sinon = require('sinon');
-const { noop } = require('lodash');
+const { extend, includes, noop } = require('lodash');
 const HCCrawler = require('../');
 const RedisCache = require('../cache/redis');
 const CSVExporter = require('../exporter/csv');
@@ -15,494 +15,468 @@ const CSV_FILE = './tmp/result.csv';
 const JSON_FILE = './tmp/result.json';
 const ENCODING = 'utf8';
 
-describe('HCCrawler', () => {
-  let crawler;
+const DEFAULT_OPTIONS = { args: ['--no-sandbox', '--disable-dev-shm-usage'] };
 
-  afterEach(() => {
-    Crawler.prototype.crawl.restore();
+describe('HCCrawler', () => {
+  describe('HCCrawler.executablePath', () => {
+    it('works', () => {
+      const executablePath = HCCrawler.executablePath();
+      assert.ok(existsSync(executablePath));
+    });
   });
 
-  context('when crawling does not fail', () => {
-    beforeEach(() => {
-      sinon.stub(Crawler.prototype, 'crawl').returns(Promise.resolve({
-        options: {},
-        result: { title: 'Example Domain' },
-        links: ['http://www.iana.org/domains/example'],
-        screenshot: null,
-      }));
+  describe('HCCrawler.defaultArgs', () => {
+    it('returns the default chrome arguments', () => {
+      const args = HCCrawler.defaultArgs();
+      assert.ok(includes(args, '--no-first-run'));
+    });
+  });
+
+  describe('HCCrawler.launch', () => {
+    let crawler;
+
+    afterEach(() => {
+      Crawler.prototype.crawl.restore();
     });
 
-    context('when the crawler is launched without necessary options', () => {
-      beforeEach(() => (
-        HCCrawler.launch()
-          .then(_crawler => {
-            crawler = _crawler;
-          })
-      ));
-
-      afterEach(() => crawler.close());
-
-      it('throws an error when queueing null', () => {
-        assert.throws(() => {
-          crawler.queue(null);
-        });
+    context('when crawling does not fail', () => {
+      beforeEach(() => {
+        sinon.stub(Crawler.prototype, 'crawl').returns(Promise.resolve({
+          options: {},
+          result: { title: 'Example Domain' },
+          links: ['http://www.iana.org/domains/example'],
+          screenshot: null,
+        }));
       });
 
-      it('throws an error when queueing options without URL', () => {
-        assert.throws(() => {
-          crawler.queue();
-        });
-      });
-
-      it('crawls when queueing necessary options', () => {
-        crawler.queue({ url: URL1 });
-        return crawler.onIdle()
-          .then(() => {
-            assert.equal(crawler.requestedCount(), 1);
-          });
-      });
-    });
-
-    context('when the crawler is launched with necessary options', () => {
-      beforeEach(() => (
-        HCCrawler.launch()
-          .then(_crawler => {
-            crawler = _crawler;
-          })
-      ));
-
-      afterEach(() => crawler.close());
-
-      it('crawls when queueing a string', () => {
-        crawler.queue(URL1);
-        return crawler.onIdle()
-          .then(() => {
-            assert.equal(crawler.requestedCount(), 1);
-          });
-      });
-
-      it('crawls when queueing multiple strings', () => {
-        crawler.queue([URL1, URL2, URL3]);
-        return crawler.onIdle()
-          .then(() => {
-            assert.equal(crawler.requestedCount(), 3);
-          });
-      });
-
-      it('crawls when queueing an object', () => {
-        crawler.queue({ url: URL1 });
-        return crawler.onIdle()
-          .then(() => {
-            assert.equal(crawler.requestedCount(), 1);
-          });
-      });
-
-      it('crawls when queueing multiple objects', () => {
-        crawler.queue([{ url: URL1 }, { url: URL2 }, { url: URL3 }]);
-        return crawler.onIdle()
-          .then(() => {
-            assert.equal(crawler.requestedCount(), 3);
-          });
-      });
-
-      it('crawls when queueing mixed styles', () => {
-        crawler.queue([URL1, { url: URL2 }]);
-        crawler.queue(URL3);
-        return crawler.onIdle()
-          .then(() => {
-            assert.equal(crawler.requestedCount(), 3);
-          });
-      });
-
-      it('throws an error when overriding onSuccess', () => {
-        assert.throws(() => {
-          crawler.queue({ url: URL1, onSuccess: noop });
-        });
-      });
-
-      it('throws an error when queueing options with unavailable device', () => {
-        assert.throws(() => {
-          crawler.queue({ url: URL1, device: 'do-not-exist' });
-        });
-      });
-
-      it('throws an error when delay is set', () => {
-        assert.throws(() => {
-          crawler.queue({ url: URL1, delay: 100 });
-        });
-      });
-
-      it('crawls when the requested domain is allowed', () => {
-        let requestskipped = 0;
-        crawler.on('requestskipped', () => { requestskipped += 1; });
-        crawler.queue({ url: URL1, allowedDomains: ['example.com', 'example.net'] });
-        return crawler.onIdle()
-          .then(() => {
-            assert.equal(requestskipped, 0);
-            assert.equal(crawler.requestedCount(), 1);
-          });
-      });
-
-      it('skips crawling when the requested domain is not allowed', () => {
-        let requestskipped = 0;
-        crawler.on('requestskipped', () => { requestskipped += 1; });
-        crawler.queue({ url: URL1, allowedDomains: ['example.net', 'example.org'] });
-        return crawler.onIdle()
-          .then(() => {
-            assert.equal(requestskipped, 1);
-            assert.equal(crawler.requestedCount(), 0);
-          });
-      });
-
-      it('emits request events', () => {
-        let requeststarted = 0;
-        let requestfinished = 0;
-        crawler.on('requeststarted', () => { requeststarted += 1; });
-        crawler.on('requestfinished', () => { requestfinished += 1; });
-        crawler.queue(URL1);
-        return crawler.onIdle()
-          .then(() => {
-            assert.equal(requeststarted, 1);
-            assert.equal(requestfinished, 1);
-          });
-      });
-    });
-
-    context('when the crawler is launched with preRequest returns true', () => {
-      function preRequest() {
-        return true;
-      }
-
-      beforeEach(() => (
-        HCCrawler.launch({ preRequest })
-          .then(_crawler => {
-            crawler = _crawler;
-          })
-      ));
-
-      afterEach(() => crawler.close());
-
-      it('does not skip crawling', () => {
-        let requestskipped = 0;
-        crawler.on('requestskipped', () => { requestskipped += 1; });
-        crawler.queue(URL1);
-        return crawler.onIdle()
-          .then(() => {
-            assert.equal(requestskipped, 0);
-            assert.equal(crawler.requestedCount(), 1);
-          });
-      });
-    });
-
-    context('when the crawler is launched with preRequest returns false', () => {
-      function preRequest() {
-        return false;
-      }
-
-      beforeEach(() => (
-        HCCrawler.launch({ preRequest })
-          .then(_crawler => {
-            crawler = _crawler;
-          })
-      ));
-
-      afterEach(() => crawler.close());
-
-      it('skips crawling', () => {
-        let requestskipped = 0;
-        crawler.on('requestskipped', () => { requestskipped += 1; });
-        crawler.queue(URL1);
-        return crawler.onIdle()
-          .then(() => {
-            assert.equal(requestskipped, 1);
-            assert.equal(crawler.requestedCount(), 0);
-          });
-      });
-    });
-
-    context('when the crawler is launched with preRequest modifies options', () => {
-      const path = './tmp/example.png';
-      function preRequest(options) {
-        options.screenshot = { path };
-        return true;
-      }
-
-      beforeEach(() => (
-        HCCrawler.launch({ preRequest })
-          .then(_crawler => {
-            crawler = _crawler;
-          })
-      ));
-
-      afterEach(() => crawler.close());
-
-      it('modifies options', () => {
-        crawler.queue(URL1);
-        return crawler.onIdle()
-          .then(() => {
-            const { screenshot } = Crawler.prototype.crawl.firstCall.thisValue._options;
-            assert.deepEqual(screenshot, { path });
-          });
-      });
-    });
-
-    context('when the crawler is launched with device option', () => {
-      beforeEach(() => (
-        HCCrawler.launch({ device: 'iPhone 6' })
-          .then(_crawler => {
-            crawler = _crawler;
-          })
-      ));
-
-      afterEach(() => crawler.close());
-
-      it('overrides device by queueing options', () => {
-        crawler.queue({ url: URL1, device: 'Nexus 6' });
-        return crawler.onIdle()
-          .then(() => {
-            assert.equal(crawler.requestedCount(), 1);
-            assert.equal(Crawler.prototype.crawl.firstCall.thisValue._options.device, 'Nexus 6');
-          });
-      });
-    });
-
-    context('when the crawler is launched with maxDepth = 2', () => {
-      beforeEach(() => (
-        HCCrawler.launch({ maxDepth: 2 })
-          .then(_crawler => {
-            crawler = _crawler;
-          })
-      ));
-
-      afterEach(() => crawler.close());
-
-      it('automatically follows links', () => {
-        let maxdepthreached = 0;
-        crawler.on('maxdepthreached', () => { maxdepthreached += 1; });
-        crawler.queue(URL1);
-        return crawler.onIdle()
-          .then(() => {
-            assert.equal(maxdepthreached, 1);
-            assert.equal(crawler.requestedCount(), 2);
-          });
-      });
-    });
-
-    context('when the crawler is launched with maxConcurrency = 1', () => {
-      beforeEach(() => (
-        HCCrawler.launch({ maxConcurrency: 1 })
-          .then(_crawler => {
-            crawler = _crawler;
-          })
-      ));
-
-      afterEach(() => crawler.close());
-
-      it('obeys priority order', () => {
-        crawler.queue({ url: URL1, priority: 1 });
-        crawler.queue({ url: URL2, priority: 2 });
-        return crawler.onIdle()
-          .then(() => {
-            assert.equal(crawler.requestedCount(), 2);
-            assert.equal(Crawler.prototype.crawl.firstCall.thisValue._options.url, URL2);
-            assert.equal(Crawler.prototype.crawl.secondCall.thisValue._options.url, URL1);
-          });
-      });
-
-      it('does not throw an error when delay option is set', () => {
-        crawler.queue({ url: URL1, delay: 100 });
-        return crawler.onIdle()
-          .then(() => {
-            assert.equal(crawler.requestedCount(), 1);
-          });
-      });
-    });
-
-    context('when the crawler is launched with maxRequest option', () => {
-      beforeEach(() => (
-        HCCrawler.launch({ maxConcurrency: 1, maxRequest: 2 })
-          .then(_crawler => {
-            crawler = _crawler;
-          })
-      ));
-
-      afterEach(() => crawler.close());
-
-      it('pauses at maxRequest option', () => {
-        let maxrequestreached = 0;
-        crawler.on('maxrequestreached', () => { maxrequestreached += 1; });
-        crawler.queue(URL1);
-        crawler.queue(URL2);
-        crawler.queue(URL3);
-        return crawler.onIdle()
-          .then(() => {
-            assert.equal(maxrequestreached, 1);
-            assert.equal(crawler.isPaused(), true);
-            assert.equal(crawler.requestedCount(), 2);
-            assert.equal(crawler.pendingQueueSize(), 1);
-            return crawler.queueSize();
-          })
-          .then(size => {
-            assert.equal(size, 1);
-          });
-      });
-
-      it('resumes from maxRequest option', () => {
-        crawler.queue(URL1);
-        crawler.queue(URL2);
-        crawler.queue(URL3);
-        return crawler.onIdle()
-          .then(() => {
-            assert.equal(crawler.isPaused(), true);
-            assert.equal(crawler.requestedCount(), 2);
-            assert.equal(crawler.pendingQueueSize(), 1);
-            return crawler.queueSize();
-          })
-          .then(size => {
-            assert.equal(size, 1);
-            crawler.setMaxRequest(4);
-            crawler.resume();
-            return crawler.onIdle();
-          })
-          .then(() => {
-            assert.equal(crawler.isPaused(), false);
-            assert.equal(crawler.requestedCount(), 3);
-            assert.equal(crawler.pendingQueueSize(), 0);
-            return crawler.queueSize();
-          })
-          .then(size => {
-            assert.equal(size, 0);
-          });
-      });
-    });
-
-    context('when the crawler is launched with exporter option', () => {
-      function removeTemporaryFile(file) {
-        return new Promise(resolve => {
-          unlink(file, (() => void resolve()));
-        });
-      }
-
-      function readTemporaryFile(file) {
-        return new Promise((resolve, reject) => {
-          readFile(file, ENCODING, ((error, result) => {
-            if (error) return reject(error);
-            return resolve(result);
-          }));
-        });
-      }
-
-      afterEach(() => (
-        crawler.close()
-          .then(() => removeTemporaryFile(CSV_FILE))
-      ));
-
-      context('when the crawler is launched with exporter = CSVExporter', () => {
+      context('when the crawler is launched without necessary options', () => {
         beforeEach(() => (
-          removeTemporaryFile(CSV_FILE)
-            .then(() => {
-              const exporter = new CSVExporter({
-                file: CSV_FILE,
-                fields: ['result.title'],
-              });
-              return HCCrawler.launch({ maxConcurrency: 1, exporter })
-                .then(_crawler => {
-                  crawler = _crawler;
-                });
-            })
-        ));
-
-        it('exports a CSV file', () => {
-          crawler.queue(URL1);
-          crawler.queue(URL2);
-          return crawler.onIdle()
-            .then(() => readTemporaryFile(CSV_FILE))
-            .then(actual => {
-              const header = 'result.title\n';
-              const line1 = 'Example Domain\n';
-              const line2 = 'Example Domain\n';
-              const expected = header + line1 + line2;
-              assert.equal(actual, expected);
-            });
-        });
-      });
-
-      context('when the crawler is launched with exporter = JSONLineExporter', () => {
-        beforeEach(() => (
-          removeTemporaryFile(JSON_FILE)
-            .then(() => {
-              const exporter = new JSONLineExporter({
-                file: JSON_FILE,
-                fields: ['result.title'],
-              });
-              return HCCrawler.launch({ maxConcurrency: 1, exporter })
-                .then(_crawler => {
-                  crawler = _crawler;
-                });
-            })
-        ));
-
-        it('exports a json-line file', () => {
-          crawler.queue(URL1);
-          crawler.queue(URL2);
-          return crawler.onIdle()
-            .then(() => readTemporaryFile(JSON_FILE))
-            .then(actual => {
-              const line1 = `${JSON.stringify({ result: { title: 'Example Domain' } })}\n`;
-              const line2 = `${JSON.stringify({ result: { title: 'Example Domain' } })}\n`;
-              const expected = line1 + line2;
-              assert.equal(actual, expected);
-            });
-        });
-      });
-    });
-
-    context('when the crawler is launched with default cache', () => {
-      beforeEach(() => (
-        HCCrawler.launch({ maxConcurrency: 1 })
-          .then(_crawler => {
-            crawler = _crawler;
-          })
-      ));
-
-      afterEach(() => crawler.close());
-
-      it('does not crawl already cached url', () => {
-        crawler.queue(URL1);
-        crawler.queue(URL2);
-        crawler.queue(URL1); // The queue won't be requested
-        return crawler.onIdle()
-          .then(() => {
-            assert.equal(crawler.requestedCount(), 2);
-          });
-      });
-    });
-
-    context('when the crawler is launched with redis cache', () => {
-      context('for the fist time with persistCache = true', () => {
-        beforeEach(() => (
-          HCCrawler.launch({ cache: new RedisCache(), persistCache: true })
+          HCCrawler.launch(DEFAULT_OPTIONS)
             .then(_crawler => {
               crawler = _crawler;
-              return crawler.clearCache();
             })
         ));
 
         afterEach(() => crawler.close());
 
-        it('crawls all queued urls', () => {
-          crawler.queue(URL1);
-          crawler.queue(URL2);
+        it('throws an error when queueing null', () => {
+          assert.throws(() => {
+            crawler.queue(null);
+          });
+        });
+
+        it('throws an error when queueing options without URL', () => {
+          assert.throws(() => {
+            crawler.queue();
+          });
+        });
+
+        it('crawls when queueing necessary options', () => {
+          crawler.queue({ url: URL1 });
           return crawler.onIdle()
             .then(() => {
+              assert.equal(crawler.requestedCount(), 1);
+            });
+        });
+      });
+
+      context('when the crawler is launched with necessary options', () => {
+        beforeEach(() => (
+          HCCrawler.launch(DEFAULT_OPTIONS)
+            .then(_crawler => {
+              crawler = _crawler;
+            })
+        ));
+
+        afterEach(() => crawler.close());
+
+        it('crawls when queueing a string', () => {
+          crawler.queue(URL1);
+          return crawler.onIdle()
+            .then(() => {
+              assert.equal(crawler.requestedCount(), 1);
+            });
+        });
+
+        it('crawls when queueing multiple strings', () => {
+          crawler.queue([URL1, URL2, URL3]);
+          return crawler.onIdle()
+            .then(() => {
+              assert.equal(crawler.requestedCount(), 3);
+            });
+        });
+
+        it('crawls when queueing an object', () => {
+          crawler.queue({ url: URL1 });
+          return crawler.onIdle()
+            .then(() => {
+              assert.equal(crawler.requestedCount(), 1);
+            });
+        });
+
+        it('crawls when queueing multiple objects', () => {
+          crawler.queue([{ url: URL1 }, { url: URL2 }, { url: URL3 }]);
+          return crawler.onIdle()
+            .then(() => {
+              assert.equal(crawler.requestedCount(), 3);
+            });
+        });
+
+        it('crawls when queueing mixed styles', () => {
+          crawler.queue([URL1, { url: URL2 }]);
+          crawler.queue(URL3);
+          return crawler.onIdle()
+            .then(() => {
+              assert.equal(crawler.requestedCount(), 3);
+            });
+        });
+
+        it('throws an error when overriding onSuccess', () => {
+          assert.throws(() => {
+            crawler.queue({ url: URL1, onSuccess: noop });
+          });
+        });
+
+        it('throws an error when queueing options with unavailable device', () => {
+          assert.throws(() => {
+            crawler.queue({ url: URL1, device: 'do-not-exist' });
+          });
+        });
+
+        it('throws an error when delay is set', () => {
+          assert.throws(() => {
+            crawler.queue({ url: URL1, delay: 100 });
+          });
+        });
+
+        it('crawls when the requested domain is allowed', () => {
+          let requestskipped = 0;
+          crawler.on('requestskipped', () => { requestskipped += 1; });
+          crawler.queue({ url: URL1, allowedDomains: ['example.com', 'example.net'] });
+          return crawler.onIdle()
+            .then(() => {
+              assert.equal(requestskipped, 0);
+              assert.equal(crawler.requestedCount(), 1);
+            });
+        });
+
+        it('skips crawling when the requested domain is not allowed', () => {
+          let requestskipped = 0;
+          crawler.on('requestskipped', () => { requestskipped += 1; });
+          crawler.queue({ url: URL1, allowedDomains: ['example.net', 'example.org'] });
+          return crawler.onIdle()
+            .then(() => {
+              assert.equal(requestskipped, 1);
+              assert.equal(crawler.requestedCount(), 0);
+            });
+        });
+
+        it('emits request events', () => {
+          let requeststarted = 0;
+          let requestfinished = 0;
+          crawler.on('requeststarted', () => { requeststarted += 1; });
+          crawler.on('requestfinished', () => { requestfinished += 1; });
+          crawler.queue(URL1);
+          return crawler.onIdle()
+            .then(() => {
+              assert.equal(requeststarted, 1);
+              assert.equal(requestfinished, 1);
+            });
+        });
+      });
+
+      context('when the crawler is launched with preRequest returns true', () => {
+        function preRequest() {
+          return true;
+        }
+
+        beforeEach(() => (
+          HCCrawler.launch(extend({ preRequest }, DEFAULT_OPTIONS))
+            .then(_crawler => {
+              crawler = _crawler;
+            })
+        ));
+
+        afterEach(() => crawler.close());
+
+        it('does not skip crawling', () => {
+          let requestskipped = 0;
+          crawler.on('requestskipped', () => { requestskipped += 1; });
+          crawler.queue(URL1);
+          return crawler.onIdle()
+            .then(() => {
+              assert.equal(requestskipped, 0);
+              assert.equal(crawler.requestedCount(), 1);
+            });
+        });
+      });
+
+      context('when the crawler is launched with preRequest returns false', () => {
+        function preRequest() {
+          return false;
+        }
+
+        beforeEach(() => (
+          HCCrawler.launch(extend({ preRequest }, DEFAULT_OPTIONS))
+            .then(_crawler => {
+              crawler = _crawler;
+            })
+        ));
+
+        afterEach(() => crawler.close());
+
+        it('skips crawling', () => {
+          let requestskipped = 0;
+          crawler.on('requestskipped', () => { requestskipped += 1; });
+          crawler.queue(URL1);
+          return crawler.onIdle()
+            .then(() => {
+              assert.equal(requestskipped, 1);
+              assert.equal(crawler.requestedCount(), 0);
+            });
+        });
+      });
+
+      context('when the crawler is launched with preRequest modifies options', () => {
+        const path = './tmp/example.png';
+        function preRequest(options) {
+          options.screenshot = { path };
+          return true;
+        }
+
+        beforeEach(() => (
+          HCCrawler.launch(extend({ preRequest }, DEFAULT_OPTIONS))
+            .then(_crawler => {
+              crawler = _crawler;
+            })
+        ));
+
+        afterEach(() => crawler.close());
+
+        it('modifies options', () => {
+          crawler.queue(URL1);
+          return crawler.onIdle()
+            .then(() => {
+              const { screenshot } = Crawler.prototype.crawl.firstCall.thisValue._options;
+              assert.deepEqual(screenshot, { path });
+            });
+        });
+      });
+
+      context('when the crawler is launched with device option', () => {
+        beforeEach(() => (
+          HCCrawler.launch(extend({ device: 'iPhone 6' }, DEFAULT_OPTIONS))
+            .then(_crawler => {
+              crawler = _crawler;
+            })
+        ));
+
+        afterEach(() => crawler.close());
+
+        it('overrides device by queueing options', () => {
+          crawler.queue({ url: URL1, device: 'Nexus 6' });
+          return crawler.onIdle()
+            .then(() => {
+              assert.equal(crawler.requestedCount(), 1);
+              assert.equal(Crawler.prototype.crawl.firstCall.thisValue._options.device, 'Nexus 6');
+            });
+        });
+      });
+
+      context('when the crawler is launched with maxDepth = 2', () => {
+        beforeEach(() => (
+          HCCrawler.launch(extend({ maxDepth: 2 }, DEFAULT_OPTIONS))
+            .then(_crawler => {
+              crawler = _crawler;
+            })
+        ));
+
+        afterEach(() => crawler.close());
+
+        it('automatically follows links', () => {
+          let maxdepthreached = 0;
+          crawler.on('maxdepthreached', () => { maxdepthreached += 1; });
+          crawler.queue(URL1);
+          return crawler.onIdle()
+            .then(() => {
+              assert.equal(maxdepthreached, 1);
               assert.equal(crawler.requestedCount(), 2);
             });
         });
       });
 
-      context('for the second time', () => {
+      context('when the crawler is launched with maxConcurrency = 1', () => {
         beforeEach(() => (
-          HCCrawler.launch({ cache: new RedisCache() })
+          HCCrawler.launch(extend({ maxConcurrency: 1 }, DEFAULT_OPTIONS))
+            .then(_crawler => {
+              crawler = _crawler;
+            })
+        ));
+
+        afterEach(() => crawler.close());
+
+        it('obeys priority order', () => {
+          crawler.queue({ url: URL1, priority: 1 });
+          crawler.queue({ url: URL2, priority: 2 });
+          return crawler.onIdle()
+            .then(() => {
+              assert.equal(crawler.requestedCount(), 2);
+              assert.equal(Crawler.prototype.crawl.firstCall.thisValue._options.url, URL2);
+              assert.equal(Crawler.prototype.crawl.secondCall.thisValue._options.url, URL1);
+            });
+        });
+
+        it('does not throw an error when delay option is set', () => {
+          crawler.queue({ url: URL1, delay: 100 });
+          return crawler.onIdle()
+            .then(() => {
+              assert.equal(crawler.requestedCount(), 1);
+            });
+        });
+      });
+
+      context('when the crawler is launched with maxRequest option', () => {
+        beforeEach(() => (
+          HCCrawler.launch(extend({ maxConcurrency: 1, maxRequest: 2 }, DEFAULT_OPTIONS))
+            .then(_crawler => {
+              crawler = _crawler;
+            })
+        ));
+
+        afterEach(() => crawler.close());
+
+        it('pauses at maxRequest option', () => {
+          let maxrequestreached = 0;
+          crawler.on('maxrequestreached', () => { maxrequestreached += 1; });
+          crawler.queue(URL1);
+          crawler.queue(URL2);
+          crawler.queue(URL3);
+          return crawler.onIdle()
+            .then(() => {
+              assert.equal(maxrequestreached, 1);
+              assert.equal(crawler.isPaused(), true);
+              assert.equal(crawler.requestedCount(), 2);
+              assert.equal(crawler.pendingQueueSize(), 1);
+              return crawler.queueSize();
+            })
+            .then(size => {
+              assert.equal(size, 1);
+            });
+        });
+
+        it('resumes from maxRequest option', () => {
+          crawler.queue(URL1);
+          crawler.queue(URL2);
+          crawler.queue(URL3);
+          return crawler.onIdle()
+            .then(() => {
+              assert.equal(crawler.isPaused(), true);
+              assert.equal(crawler.requestedCount(), 2);
+              assert.equal(crawler.pendingQueueSize(), 1);
+              return crawler.queueSize();
+            })
+            .then(size => {
+              assert.equal(size, 1);
+              crawler.setMaxRequest(4);
+              crawler.resume();
+              return crawler.onIdle();
+            })
+            .then(() => {
+              assert.equal(crawler.isPaused(), false);
+              assert.equal(crawler.requestedCount(), 3);
+              assert.equal(crawler.pendingQueueSize(), 0);
+              return crawler.queueSize();
+            })
+            .then(size => {
+              assert.equal(size, 0);
+            });
+        });
+      });
+
+      context('when the crawler is launched with exporter option', () => {
+        function removeTemporaryFile(file) {
+          return new Promise(resolve => {
+            unlink(file, (() => void resolve()));
+          });
+        }
+
+        function readTemporaryFile(file) {
+          return new Promise((resolve, reject) => {
+            readFile(file, ENCODING, ((error, result) => {
+              if (error) return reject(error);
+              return resolve(result);
+            }));
+          });
+        }
+
+        afterEach(() => (
+          crawler.close()
+            .then(() => removeTemporaryFile(CSV_FILE))
+        ));
+
+        context('when the crawler is launched with exporter = CSVExporter', () => {
+          beforeEach(() => (
+            removeTemporaryFile(CSV_FILE)
+              .then(() => {
+                const exporter = new CSVExporter({
+                  file: CSV_FILE,
+                  fields: ['result.title'],
+                });
+                return HCCrawler.launch(extend({ maxConcurrency: 1, exporter }, DEFAULT_OPTIONS))
+                  .then(_crawler => {
+                    crawler = _crawler;
+                  });
+              })
+          ));
+
+          it('exports a CSV file', () => {
+            crawler.queue(URL1);
+            crawler.queue(URL2);
+            return crawler.onIdle()
+              .then(() => readTemporaryFile(CSV_FILE))
+              .then(actual => {
+                const header = 'result.title\n';
+                const line1 = 'Example Domain\n';
+                const line2 = 'Example Domain\n';
+                const expected = header + line1 + line2;
+                assert.equal(actual, expected);
+              });
+          });
+        });
+
+        context('when the crawler is launched with exporter = JSONLineExporter', () => {
+          beforeEach(() => (
+            removeTemporaryFile(JSON_FILE)
+              .then(() => {
+                const exporter = new JSONLineExporter({
+                  file: JSON_FILE,
+                  fields: ['result.title'],
+                });
+                return HCCrawler.launch(extend({ maxConcurrency: 1, exporter }, DEFAULT_OPTIONS))
+                  .then(_crawler => {
+                    crawler = _crawler;
+                  });
+              })
+          ));
+
+          it('exports a json-line file', () => {
+            crawler.queue(URL1);
+            crawler.queue(URL2);
+            return crawler.onIdle()
+              .then(() => readTemporaryFile(JSON_FILE))
+              .then(actual => {
+                const line1 = `${JSON.stringify({ result: { title: 'Example Domain' } })}\n`;
+                const line2 = `${JSON.stringify({ result: { title: 'Example Domain' } })}\n`;
+                const expected = line1 + line2;
+                assert.equal(actual, expected);
+              });
+          });
+        });
+      });
+
+      context('when the crawler is launched with default cache', () => {
+        beforeEach(() => (
+          HCCrawler.launch(extend({ maxConcurrency: 1 }, DEFAULT_OPTIONS))
             .then(_crawler => {
               crawler = _crawler;
             })
@@ -511,98 +485,144 @@ describe('HCCrawler', () => {
         afterEach(() => crawler.close());
 
         it('does not crawl already cached url', () => {
+          crawler.queue(URL1);
           crawler.queue(URL2);
-          crawler.queue(URL3);
+          crawler.queue(URL1); // The queue won't be requested
           return crawler.onIdle()
             .then(() => {
-              assert.equal(crawler.requestedCount(), 1);
+              assert.equal(crawler.requestedCount(), 2);
             });
         });
       });
-    });
 
-    context('when the crawler is with skipDuplicates = false', () => {
-      beforeEach(() => (
-        HCCrawler.launch({ maxConcurrency: 1, skipDuplicates: false })
+      context('when the crawler is launched with redis cache', () => {
+        context('for the fist time with persistCache = true', () => {
+          beforeEach(() => {
+            const cache = new RedisCache();
+            return HCCrawler.launch(extend({ cache, persistCache: true }, DEFAULT_OPTIONS))
+              .then(_crawler => {
+                crawler = _crawler;
+                return crawler.clearCache();
+              });
+          });
+
+          afterEach(() => crawler.close());
+
+          it('crawls all queued urls', () => {
+            crawler.queue(URL1);
+            crawler.queue(URL2);
+            return crawler.onIdle()
+              .then(() => {
+                assert.equal(crawler.requestedCount(), 2);
+              });
+          });
+        });
+
+        context('for the second time', () => {
+          beforeEach(() => {
+            const cache = new RedisCache();
+            return HCCrawler.launch(extend({ cache }, DEFAULT_OPTIONS))
+              .then(_crawler => {
+                crawler = _crawler;
+              });
+          });
+
+          afterEach(() => crawler.close());
+
+          it('does not crawl already cached url', () => {
+            crawler.queue(URL2);
+            crawler.queue(URL3);
+            return crawler.onIdle()
+              .then(() => {
+                assert.equal(crawler.requestedCount(), 1);
+              });
+          });
+        });
+      });
+
+      context('when the crawler is with skipDuplicates = false', () => {
+        beforeEach(() => (
+          HCCrawler.launch(extend({ maxConcurrency: 1, skipDuplicates: false }, DEFAULT_OPTIONS))
+            .then(_crawler => {
+              crawler = _crawler;
+            })
+        ));
+
+        afterEach(() => crawler.close());
+
+        it('crawls duplicate urls', () => {
+          crawler.queue(URL1);
+          crawler.queue(URL2);
+          crawler.queue(URL1); // The queue will be requested
+          return crawler.onIdle()
+            .then(() => {
+              assert.equal(crawler.requestedCount(), 3);
+            });
+        });
+      });
+
+      context('when the crawler is launched with onSuccess', () => {
+        const onSuccess = sinon.spy();
+
+        beforeEach(() => (
+          HCCrawler.launch(extend({ onSuccess }, DEFAULT_OPTIONS))
+            .then(_crawler => {
+              crawler = _crawler;
+            })
+        ));
+
+        afterEach(() => crawler.close());
+
+        it('does not skip crawling', () => {
+          crawler.queue(URL1);
+          return crawler.onIdle()
+            .then(() => {
+              assert.equal(crawler.requestedCount(), 1);
+              assert.equal(onSuccess.callCount, 1);
+            });
+        });
+      });
+
+      it('emits disconnect event', () => {
+        let disconnected = 0;
+        return HCCrawler.launch(DEFAULT_OPTIONS)
           .then(_crawler => {
             crawler = _crawler;
           })
-      ));
-
-      afterEach(() => crawler.close());
-
-      it('crawls duplicate urls', () => {
-        crawler.queue(URL1);
-        crawler.queue(URL2);
-        crawler.queue(URL1); // The queue will be requested
-        return crawler.onIdle()
-          .then(() => {
-            assert.equal(crawler.requestedCount(), 3);
-          });
+          .then(() => void crawler.on('disconnected', () => { disconnected += 1; }))
+          .then(() => crawler.close())
+          .then(() => void assert.equal(disconnected, 1));
       });
     });
 
-    context('when the crawler is launched with onSuccess', () => {
-      const onSuccess = sinon.spy();
+    context('when crawling fails', () => {
+      const onError = sinon.spy();
 
-      beforeEach(() => (
-        HCCrawler.launch({ onSuccess })
+      beforeEach(() => {
+        const error = new Error('Unexpected error occured while crawling!');
+        sinon.stub(Crawler.prototype, 'crawl').returns(Promise.reject(error));
+        return HCCrawler.launch(extend({ onError }, DEFAULT_OPTIONS))
           .then(_crawler => {
             crawler = _crawler;
-          })
-      ));
+          });
+      });
 
       afterEach(() => crawler.close());
 
-      it('does not skip crawling', () => {
-        crawler.queue(URL1);
+      it('retries and gives up', () => {
+        let requestretried = 0;
+        let requestfailed = 0;
+        crawler.on('requestretried', () => { requestretried += 1; });
+        crawler.on('requestfailed', () => { requestfailed += 1; });
+        crawler.queue({ url: URL1, retryCount: 3, retryDelay: 100 });
         return crawler.onIdle()
           .then(() => {
             assert.equal(crawler.requestedCount(), 1);
-            assert.equal(onSuccess.callCount, 1);
+            assert.equal(requestretried, 3);
+            assert.equal(requestfailed, 1);
+            assert.equal(onError.callCount, 1);
           });
       });
-    });
-
-    it('emits disconnect event', () => {
-      let disconnected = 0;
-      return HCCrawler.launch()
-        .then(_crawler => {
-          crawler = _crawler;
-        })
-        .then(() => void crawler.on('disconnected', () => { disconnected += 1; }))
-        .then(() => crawler.close())
-        .then(() => void assert.equal(disconnected, 1));
-    });
-  });
-
-  context('when crawling fails', () => {
-    const onError = sinon.spy();
-
-    beforeEach(() => {
-      const error = new Error('Unexpected error occured while crawling!');
-      sinon.stub(Crawler.prototype, 'crawl').returns(Promise.reject(error));
-      return HCCrawler.launch({ onError })
-        .then(_crawler => {
-          crawler = _crawler;
-        });
-    });
-
-    afterEach(() => crawler.close());
-
-    it('retries and gives up', () => {
-      let requestretried = 0;
-      let requestfailed = 0;
-      crawler.on('requestretried', () => { requestretried += 1; });
-      crawler.on('requestfailed', () => { requestfailed += 1; });
-      crawler.queue({ url: URL1, retryCount: 3, retryDelay: 100 });
-      return crawler.onIdle()
-        .then(() => {
-          assert.equal(crawler.requestedCount(), 1);
-          assert.equal(requestretried, 3);
-          assert.equal(requestfailed, 1);
-          assert.equal(onError.callCount, 1);
-        });
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1416,9 +1416,9 @@ punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
-puppeteer@0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-0.13.0.tgz#2e6956205f2c640964c2107f620ae1eef8bde8fd"
+puppeteer@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.0.0.tgz#20f3bb6ad6c6778b4d1fb750e808a29fec0a88a4"
   dependencies:
     debug "^2.6.8"
     extract-zip "^1.6.5"


### PR DESCRIPTION
- Update [puppeteer](https://github.com/GoogleChrome/puppeteer) from 0.13.0 to 1.0.0
- Add `HCCrawler.defaultArgs()`
- Pass args to launch to speed up tests

Fixes: https://github.com/yujiosaka/headless-chrome-crawler/issues/64