### PR TITLE
Bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.3.0] - 2018-01-12
+### Added
+
+- Add [HCCrawler.defaultArgs()](https://github.com/yujiosaka/headless-chrome-crawler#hccrawlerdefaultargs) method.
+- Emit `requestretried` event.
+
+### changed
+
+- Use `cache` option not only for remembering already requested URLs but for request queue for distributed environments.
+- Moved `onSuccess`, `onError` and `maxDepth` options from [HCCrawler.connect()](https://github.com/yujiosaka/headless-chrome-crawler#hccrawlerconnectoptions) and [HCCrawler.launch()](https://github.com/yujiosaka/headless-chrome-crawler#hccrawlerlaunchoptions) to [crawler.queue()](https://github.com/yujiosaka/headless-chrome-crawler#crawlerqueueoptions).
+
 ## [1.2.5] - 2018-01-03
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headless-chrome-crawler",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "description": "Headless Chrome crawls with jQuery support",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
### Added

- Add [HCCrawler.defaultArgs()] method.
- Add `requestretried` event.

### changed

- Use `cache` option not only for remembering already requested URLs but for request queue for distributed environments.
- Moved `onSuccess`, `onError` and `maxDepth` options from [HCCrawler.connect()](https://github.com/yujiosaka/headless-chrome-crawler#hccrawlerconnectoptions) and [HCCrawler.launch()](https://github.com/yujiosaka/headless-chrome-crawler#hccrawlerlaunchoptions) to [crawler.queue()](https://github.com/yujiosaka/headless-chrome-crawler#crawlerqueueoptions).