### PR TITLE
fix response

### DIFF
--- a/lib/hccrawler.js
+++ b/lib/hccrawler.js
@@ -5,6 +5,7 @@ const {
   omit,
   extend,
   each,
+  reduce,
   includes,
   some,
   endsWith,
@@ -303,7 +304,11 @@ class HCCrawler extends EventEmitter {
       .then(crawler => (
         crawler.crawl()
           .then(res => {
-            res.response = pick(res.response, RESPONSE_FIELDS);
+            res = extend({}, res);
+            res.response = reduce(RESPONSE_FIELDS, (memo, field) => {
+              memo[field] = res.response[field]();
+              return memo;
+            }, {});
             res.options = options;
             res.depth = depth;
             this.emit(HCCrawler.Events.RequestFinished, res);

--- a/test/hccrawler.test.js
+++ b/test/hccrawler.test.js
@@ -45,6 +45,12 @@ describe('HCCrawler', () => {
         onSuccess = sinon.spy();
         sinon.stub(Crawler.prototype, 'crawl').returns(Promise.resolve({
           options: {},
+          response: {
+            ok: (() => true),
+            url: (() => 'https://example.com/'),
+            status: (() => 200),
+            headers: (() => {}),
+          },
           result: { title: 'Example Domain' },
           links: ['http://www.iana.org/domains/example'],
           screenshot: null,
@@ -322,8 +328,8 @@ describe('HCCrawler', () => {
           return crawler.onIdle()
             .then(() => {
               assert.equal(onSuccess.callCount, 2);
-              assert.equal(Crawler.prototype.crawl.firstCall.thisValue._options.url, URL2);
-              assert.equal(Crawler.prototype.crawl.secondCall.thisValue._options.url, URL1);
+              assert.equal(onSuccess.firstCall.args[0].options.url, URL2);
+              assert.equal(onSuccess.secondCall.args[0].options.url, URL1);
             });
         });
 


### PR DESCRIPTION
The response does not list the properties but methods.
The bug started when updating puppeteer's version at #65 .