### PR TITLE
Reduce response object in crawler rather than hccrawler

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -1,4 +1,5 @@
 const {
+  reduce,
   pick,
   isEmpty,
   uniq,
@@ -15,6 +16,12 @@ const {
 const GOTO_OPTIONS = [
   'timeout',
   'waitUntil',
+];
+const RESPONSE_FIELDS = [
+  'ok',
+  'url',
+  'status',
+  'headers',
 ];
 
 const jQueryPath = require.resolve('jquery');
@@ -42,7 +49,7 @@ class Crawler {
           this._collectLinks(response.url),
         ])
           .then(([result, screenshot, links]) => ({
-            response,
+            response: this._reduceResponse(response),
             result,
             screenshot,
             links,
@@ -212,6 +219,18 @@ class Crawler {
         })
       ))
       .then(() => uniq(links));
+  }
+
+  /**
+   * @param {!Response} response
+   * @return {!Object}
+   * @private
+   */
+  _reduceResponse(response) {
+    return reduce(RESPONSE_FIELDS, (memo, field) => {
+      memo[field] = response[field]();
+      return memo;
+    }, {});
   }
 }
 

--- a/lib/hccrawler.js
+++ b/lib/hccrawler.js
@@ -6,7 +6,6 @@ const {
   extend,
   map,
   each,
-  reduce,
   includes,
   some,
   endsWith,
@@ -58,12 +57,6 @@ const CONSTRUCTOR_OPTIONS = CONNECT_OPTIONS.concat(LAUNCH_OPTIONS).concat([
   'onSuccess',
   'onError',
 ]);
-const RESPONSE_FIELDS = [
-  'ok',
-  'url',
-  'status',
-  'headers',
-];
 const EMPTY_TXT = '';
 
 const deviceNames = Object.keys(devices);
@@ -332,10 +325,6 @@ class HCCrawler extends EventEmitter {
         crawler.crawl()
           .then(res => {
             res = extend({}, res);
-            res.response = reduce(RESPONSE_FIELDS, (memo, field) => {
-              memo[field] = res.response[field]();
-              return memo;
-            }, {});
             res.options = options;
             res.depth = depth;
             this.emit(HCCrawler.Events.RequestFinished, res);

--- a/test/hccrawler.test.js
+++ b/test/hccrawler.test.js
@@ -46,10 +46,10 @@ describe('HCCrawler', () => {
         sinon.stub(Crawler.prototype, 'crawl').returns(Promise.resolve({
           options: {},
           response: {
-            ok: (() => true),
-            url: (() => 'https://example.com/'),
-            status: (() => 200),
-            headers: (() => {}),
+            ok: true,
+            url: 'https://example.com/',
+            status: 200,
+            headers: {},
           },
           result: { title: 'Example Domain' },
           links: ['http://www.iana.org/domains/example'],


### PR DESCRIPTION
It doesn't affect public API, but it keeps the code clean.