### PR TITLE
Revert "feat: support depthPriority option"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Emit `newpage` event.
-- Support `deniedDomains` and `depthPriority` for [crawler.queue()](https://github.com/yujiosaka/headless-chrome-crawler#crawlerqueueoptions)'s options.
+- Support `deniedDomains` for [crawler.queue()](https://github.com/yujiosaka/headless-chrome-crawler#crawlerqueueoptions)'s options.
 
 ### changed
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Powered by Headless Chrome, the crawler provides [simple APIs](#api-reference) t
 
 * Distributed crawling
 * Configure concurrency, delay and retry
-* Support both [depth-first search](https://en.wikipedia.org/wiki/Depth-first_search) and [breadth-first search](https://en.wikipedia.org/wiki/Breadth-first_search) algorithm
+* Breadth-first search (BFS) to automatically follow links
 * Pluggable cache storages such as [Redis](https://redis.io)
 * Support [CSV](https://tools.ietf.org/html/rfc4180) and [JSON Lines](http://jsonlines.org) for exporting results
 * Pause at the max request and resume at any time
@@ -180,7 +180,7 @@ browserWSEndpoint, ignoreHTTPSErrors
 Also, the following options can be set as default values when [crawler.queue()](#crawlerqueueoptions) are executed.
 
 ```
-url, allowedDomains, deniedDomains, timeout, priority, depthPriority, delay, retryCount, retryDelay, jQuery, device, username, password, evaluatePage
+url, allowedDomains, deniedDomains, timeout, priority, delay, retryCount, retryDelay, jQuery, device, username, password, evaluatePage
 ```
 
 > **Note**: In practice, setting the options every time you queue equests is redundant. Therefore, it's recommended to set the default values and override them depending on the necessity.
@@ -220,7 +220,7 @@ ignoreHTTPSErrors, headless, executablePath, slowMo, args, ignoreDefaultArgs, ha
 Also, the following options can be set as default values when [crawler.queue()](#crawlerqueueoptions) are executed.
 
 ```
-url, allowedDomains, deniedDomains, timeout, priority, depthPriority, delay, retryCount, retryDelay, jQuery, device, username, password, evaluatePage
+url, allowedDomains, deniedDomains, timeout, priority, delay, retryCount, retryDelay, jQuery, device, username, password, evaluatePage
 ```
 
 > **Note**: In practice, setting the options every time you queue the requests is redundant. Therefore, it's recommended to set the default values and override them depending on the necessity.
@@ -239,7 +239,6 @@ url, allowedDomains, deniedDomains, timeout, priority, depthPriority, delay, ret
   * `url` <[string]> Url to navigate to. The url should include scheme, e.g. `https://`.
   * `maxDepth` <[number]> Maximum depth for the crawler to follow links automatically, default to 1. Leave default to disable following links.
   * `priority` <[number]> Basic priority of queues, defaults to `1`. Priority with larger number is preferred.
-  * `depthPriority` <[boolean]> Whether to adjust priority based on its depth, defaults to `true`. Leave default to increase priority for higher depth, which is [depth-first search](https://en.wikipedia.org/wiki/Depth-first_search).
   * `skipDuplicates` <[boolean]> Whether to skip duplicate requests, default to `null`. The request is considered to be the same if `url`, `userAgent`, `device` and `extraHeaders` are strictly the same.
   * `obeyRobotsTxt` <[boolean]> Whether to obey [robots.txt](https://developers.google.com/search/reference/robots_txt), default to `true`.
   * `followSitemapXml` <[boolean]> Whether to use [sitemap.xml](https://www.sitemaps.org/) to find locations, default to `false`.

--- a/lib/hccrawler.js
+++ b/lib/hccrawler.js
@@ -113,7 +113,6 @@ class HCCrawler extends EventEmitter {
       jQuery: true,
       persistCache: false,
       skipDuplicates: true,
-      depthPriority: true,
       obeyRobotsTxt: true,
       followSitemapXml: false,
       screenshot: null,
@@ -129,7 +128,7 @@ class HCCrawler extends EventEmitter {
     this._onSuccess = options.onSuccess || null;
     this._onError = options.onError || null;
     this._exportHeader();
-    this._queue.on('pull', (...args) => this._startRequest(...args));
+    this._queue.on('pull', (...args) => this._onPull(...args));
     this._browser.on('disconnected', () => {
       this.emit(HCCrawler.Events.Disconnected);
     });
@@ -159,7 +158,7 @@ class HCCrawler extends EventEmitter {
       if (!mergedOptions.url) throw new Error('Url must be defined!');
       if (mergedOptions.device && !includes(deviceNames, mergedOptions.device)) throw new Error('Specified device is not supported!');
       if (mergedOptions.delay > 0 && mergedOptions.maxConcurrency !== 1) throw new Error('Max concurrency must be 1 when delay is set!');
-      this._push(omit(mergedOptions, CONSTRUCTOR_OPTIONS), 1);
+      this._push(omit(mergedOptions, CONSTRUCTOR_OPTIONS));
     });
   }
 
@@ -267,12 +266,10 @@ class HCCrawler extends EventEmitter {
 
   /**
    * @param {!Object} options
-   * @param {!number} depth
+   * @param {!number=} depth
    */
-  _push(options, depth) {
-    let { priority } = options;
-    if (!priority && options.depthPriority) priority = depth;
-    this._queue.push(options, depth, priority);
+  _push(options, depth = 1) {
+    this._queue.push(options, depth, options.priority);
   }
 
   /**
@@ -281,7 +278,7 @@ class HCCrawler extends EventEmitter {
    * @return {!Promise}
    * @private
    */
-  _startRequest(options, depth) {
+  _onPull(options, depth) {
     return this._skipRequest(options)
       .then(skip => {
         if (skip) {
@@ -289,11 +286,7 @@ class HCCrawler extends EventEmitter {
           return Promise.resolve();
         }
         return this._followSitemap(options, depth)
-          .then(() => this._request(options, depth))
-          .then(links => {
-            this._checkRequestCount();
-            return delay(options.delay).then(() => this._followLinks(links, options, depth));
-          });
+          .then(() => this._request(options, depth));
       });
   }
 
@@ -310,7 +303,9 @@ class HCCrawler extends EventEmitter {
       this._shouldRequest(options),
     ])
       .then(([requested, allowedRobot, allowedDomain, shouldRequest]) => {
-        if (requested || !allowedRobot || !allowedDomain || !shouldRequest) return true;
+        if (requested || !allowedRobot || !allowedDomain || !shouldRequest) {
+          return true;
+        }
         return false;
       });
   }
@@ -319,7 +314,7 @@ class HCCrawler extends EventEmitter {
    * @param {!Object} options
    * @param {!number} depth
    * @param {!number=} retryCount
-   * @return {!Promise<!Array<!string>}
+   * @return {!Promise}
    * @private
    */
   _request(options, depth, retryCount = 0) {
@@ -329,12 +324,18 @@ class HCCrawler extends EventEmitter {
         this.emit(HCCrawler.Events.NewPage, crawler.page());
         return crawler.crawl()
           .then(res => {
-            res = extend({ options, depth }, res);
+            res = extend({}, res);
+            res.options = options;
+            res.depth = depth;
             this.emit(HCCrawler.Events.RequestFinished, res);
             return this._success(res)
-              .then(() => { void this._exportLine(res); })
+              .then(() => {
+                this._exportLine(res);
+                this._checkRequestCount();
+                this._followLinks(res.links, options, depth);
+              })
               .then(() => crawler.close())
-              .then(() => res.links);
+              .then(() => delay(options.delay));
           })
           .catch(error => {
             if (retryCount >= options.retryCount) throw error;
@@ -347,8 +348,9 @@ class HCCrawler extends EventEmitter {
           .catch(error => {
             this.emit(HCCrawler.Events.RequestFailed, error);
             return this._error(error)
+              .then(() => void this._checkRequestCount())
               .then(() => crawler.close())
-              .then(() => []);
+              .then(() => delay(options.delay));
           });
       });
   }

--- a/test/hccrawler.test.js
+++ b/test/hccrawler.test.js
@@ -512,38 +512,6 @@ describe('HCCrawler', () => {
               assert.equal(onSuccess.callCount, 3);
             });
         });
-
-        context('when the first page contains several links', () => {
-          beforeEach(() => {
-            server.setContent('/1.html', `
-            go to <a href="${PREFIX}/2.html">/2.html</a>
-            go to <a href="${PREFIX}/3.html">/3.html</a>
-            `);
-            server.setContent('/2.html', `go to <a href="${PREFIX}/4.html">/4.html</a>`);
-          });
-
-          it('follow links with depth first order with maxDepth = 3', () => {
-            crawler.queue({ url: `${PREFIX}/1.html`, maxDepth: 3 });
-            return crawler.onIdle()
-              .then(() => {
-                assert.equal(onSuccess.callCount, 4);
-                assert.equal(onSuccess.firstCall.args[0].depth, 1);
-                assert.equal(onSuccess.secondCall.args[0].depth, 2);
-                assert.equal(onSuccess.thirdCall.args[0].depth, 3);
-              });
-          });
-
-          it('follow links with breadth first order with maxDepth = 3 and depthPriority = false', () => {
-            crawler.queue({ url: `${PREFIX}/1.html`, maxDepth: 3, depthPriority: false });
-            return crawler.onIdle()
-              .then(() => {
-                assert.equal(onSuccess.callCount, 4);
-                assert.equal(onSuccess.firstCall.args[0].depth, 1);
-                assert.equal(onSuccess.secondCall.args[0].depth, 2);
-                assert.equal(onSuccess.thirdCall.args[0].depth, 2);
-              });
-          });
-        });
       });
 
       context('when the crawler is launched with maxRequest option', () => {

--- a/test/helper.test.js
+++ b/test/helper.test.js
@@ -9,7 +9,6 @@ const {
   escapeQuotes,
   getRobotsUrl,
   lowerBound,
-  checkDomainMatch,
   getSitemapUrls,
   unescape,
   stringifyArgument,
@@ -214,38 +213,6 @@ describe('Helper', () => {
       const item = { priority: -1 };
       const actual = lowerBound(queue, item, (a, b) => b.priority - a.priority);
       const expected = 2;
-      assert.equal(actual, expected);
-    });
-  });
-
-  describe('Helper.checkDomainMatch', () => {
-    it('returns false for empty array', () => {
-      const actual = checkDomainMatch([], '127.0.0.1');
-      const expected = false;
-      assert.equal(actual, expected);
-    });
-
-    it('returns false when no domain fully matches requested hostname', () => {
-      const actual = checkDomainMatch(['localhost', '0.0.0.0'], '127.0.0.1');
-      const expected = false;
-      assert.equal(actual, expected);
-    });
-
-    it('returns false when no domain matches requested hostname by regular expression', () => {
-      const actual = checkDomainMatch([/^localhost$/, /^\d\.\d\.\d\.\d$/], '127.0.0.1');
-      const expected = false;
-      assert.equal(actual, expected);
-    });
-
-    it('returns true when a domain fully matches requested hostname', () => {
-      const actual = checkDomainMatch(['localhost', '127.0.0.1'], '127.0.0.1');
-      const expected = true;
-      assert.equal(actual, expected);
-    });
-
-    it('returns true when a domain fully matches requested hostname by regular expression', () => {
-      const actual = checkDomainMatch([/^localhost$/, /^\d+\.\d+\.\d+\.\d+$/], '127.0.0.1');
-      const expected = true;
       assert.equal(actual, expected);
     });
   });


### PR DESCRIPTION
Reverts yujiosaka/headless-chrome-crawler#109

It started requesting the same urls many times when depth-first search is enabled:

```
Requested https://www.emin.co.jp/.
Requested https://www.emin.co.jp/blog/news/1506/.
Requested https://www.emin.co.jp/contact/.
Requested https://www.emin.co.jp/blog/lab/.
Requested https://www.emin.co.jp/team/.
Requested https://www.emin.co.jp/careers/.
Requested https://www.emin.co.jp/blog/news/1539/.
Requested https://www.emin.co.jp/blog/.
Requested https://www.emin.co.jp/blog/interview/1098/.
Requested https://www.emin.co.jp/blog/news/1527/.
Requested https://www.emin.co.jp/company/.
Requested https://www.emin.co.jp/contact/.
Requested https://www.emin.co.jp/blog/news/1506/.
Requested https://www.emin.co.jp/blog/lab/.
Requested https://www.emin.co.jp/careers/.
Requested https://www.emin.co.jp/team/.
Requested https://www.emin.co.jp/blog/news/1539/.
Requested https://www.emin.co.jp/blog/.
Requested https://www.emin.co.jp/blog/news/1527/.
Requested https://www.emin.co.jp/blog/interview/1098/.
Requested https://www.emin.co.jp/company/.
Requested https://www.emin.co.jp/contact/.
Requested https://www.emin.co.jp/blog/news/1506/.
Requested https://www.emin.co.jp/team/.
Requested https://www.emin.co.jp/blog/lab/.
Requested https://www.emin.co.jp/careers/.
Requested https://www.emin.co.jp/blog/news/1539/.
Requested https://www.emin.co.jp/blog/.
Requested https://www.emin.co.jp/blog/interview/1098/.
Requested https://www.emin.co.jp/blog/news/1527/.
Requested https://www.emin.co.jp/company/.
Requested https://www.emin.co.jp/contact/.
Requested https://www.emin.co.jp/blog/news/1506/.
Requested https://www.emin.co.jp/blog/.
Requested https://www.emin.co.jp/company/.
Requested https://www.emin.co.jp/careers/.
Requested https://www.emin.co.jp/team/.
Requested https://www.emin.co.jp/blog/interview/681/.
Requested https://www.emin.co.jp/blog/lab/.
Requested https://www.emin.co.jp/careers/.
Requested https://www.emin.co.jp/blog/news/1539/.
Requested https://www.emin.co.jp/blog/.
Requested https://www.emin.co.jp/blog/category/news/.
Requested https://www.emin.co.jp/blog/interview/1098/.
Requested https://www.emin.co.jp/blog/news/1527/.
Requested https://www.emin.co.jp/company/.
Requested https://www.emin.co.jp/en/.
Requested https://www.emin.co.jp/contact/.
Requested https://www.emin.co.jp/blog/interview/638/.
Requested https://www.emin.co.jp/blog/interview/681/?share=twitter.
Requested https://www.emin.co.jp/blog/lab/.
Requested https://www.emin.co.jp/team/.
Requested https://www.emin.co.jp/blog/category/interview/.
Requested https://www.emin.co.jp/blog/interview/681/?share=google-plus-1.
Requested https://www.emin.co.jp/blog/interview/681/?share=facebook.
Requested https://www.emin.co.jp/blog/zenclerk-lite%e6%83%85%e5%a0%b1/1004/.
Requested https://www.emin.co.jp/blog/interview/462/.
Requested https://www.emin.co.jp/blog/news/1539/?share=twitter.
Requested https://www.emin.co.jp/blog/press/101/.
Requested https://www.emin.co.jp/blog/news/1539/?share=google-plus-1.
Requested https://www.emin.co.jp/info/news/172/.
Requested https://www.emin.co.jp/blog/news/1539/?share=facebook.
Requested https://www.emin.co.jp/blog/published/1390/.
Requested https://www.emin.co.jp/blog/news/401/.
Requested https://www.emin.co.jp/blog/lab/ec-system.
Requested https://www.emin.co.jp/blog/lab/ec-business.
Requested https://www.emin.co.jp/blog/news/1539/.
Requested https://www.emin.co.jp/blog/news/1506/.
Requested https://www.emin.co.jp/blog/published/1498/.
Requested https://www.emin.co.jp/blog/category/published/.
Requested https://www.emin.co.jp/blog/news/1527/.
Requested https://www.emin.co.jp/blog/category/press/.
Requested https://www.emin.co.jp/blog/published/1451/.
Requested https://www.emin.co.jp/blog/news/1415/.
Requested https://www.emin.co.jp/blog/press/1483/.
Requested https://www.emin.co.jp/blog/published/1426/.
Requested https://www.emin.co.jp/blog/published/1382/.
Requested https://www.emin.co.jp/blog/category/report/.
Requested https://www.emin.co.jp/blog/report/1363/.
Requested https://www.emin.co.jp/blog/published/1322/.
Requested https://www.emin.co.jp/blog/news/1361/.
Requested https://www.emin.co.jp/blog/published/1218/.
Requested https://www.emin.co.jp/blog/page/2/.
Requested https://www.emin.co.jp/blog/page/7/.
Requested https://www.emin.co.jp/blog/report/1291/.
Requested https://www.emin.co.jp/blog/date/2018/.
Requested https://www.emin.co.jp/blog/page/3/.
Requested https://www.emin.co.jp/blog/date/2017/.
Requested https://www.emin.co.jp/blog/date/2016/.
Requested https://www.emin.co.jp/blog/date/2015/.
Requested https://www.emin.co.jp/blog/date/2014/.
Requested https://www.emin.co.jp/blog/interview/1098/?share=twitter.
Requested https://www.emin.co.jp/blog/category/member/.
Requested https://www.emin.co.jp/blog/category/emin-infomation/.
Requested https://www.emin.co.jp/blog/category/zenclerk-information/.
Requested https://www.emin.co.jp/blog/news/1527/?share=twitter.
Requested https://www.emin.co.jp/blog/interview/1098/?share=google-plus-1.
Requested https://www.emin.co.jp/blog/category/zenclerk-lite%e6%83%85%e5%a0%b1/.
Requested https://www.emin.co.jp/blog/interview/1098/?share=facebook.
Requested https://www.emin.co.jp/blog/news/1527/?share=facebook.
Requested https://www.emin.co.jp/blog/news/1527/?share=google-plus-1.
Requested https://www.emin.co.jp/blog/news/1172/.
Requested https://www.emin.co.jp/contact/embed/.
Requested https://www.emin.co.jp/blog/interview/638/?share=twitter.
Requested https://www.emin.co.jp/blog/interview/638/?share=google-plus-1.
Requested https://www.emin.co.jp/wp-content/themes/emin/https://www.zenclerk.com/.
Requested https://www.emin.co.jp/blog/interview/638/?share=facebook.
```