### PR TITLE
chore(eslint): remove .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,0 @@
-coverage/


### PR DESCRIPTION
`/coverage` is no longer used after [istanbul dropped](https://github.com/yujiosaka/headless-chrome-crawler/pull/83)