### PR TITLE
chore: bump version to 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.5.0] - 2018-03-25
+
 ### Added
 
 - Support `waitFor` for [crawler.queue()](https://github.com/yujiosaka/headless-chrome-crawler#crawlerqueueoptions)'s options.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headless-chrome-crawler",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Distributed web crawler powered by Headless Chrome",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
### Added

- Support `waitFor` for [crawler.queue()](https://github.com/yujiosaka/headless-chrome-crawler#crawlerqueueoptions)'s options.
- Support `slowMo` for [HCCrawler.connect()](#hccrawlerconnectoptions)'s options.

### Fixed

- Fix a bug of not allowed to set `timeout` option per request.
- Fix a bug of crawling twice if one url has a trailing slash on the root folder and the other does not.