### PR TITLE
chore(hccrawler): serialize check request process

### DIFF
--- a/lib/hccrawler.js
+++ b/lib/hccrawler.js
@@ -301,16 +301,12 @@ class HCCrawler extends EventEmitter {
   async _skipRequest(options) {
     const allowedDomain = this._checkAllowedDomains(options);
     if (!allowedDomain) return true;
-    const [
-      requested,
-      allowedRobot,
-      shouldRequest,
-    ] = await Promise.all([
-      this._checkRequested(options),
-      this._checkAllowedRobots(options),
-      this._shouldRequest(options),
-    ]);
-    if (requested || !allowedRobot || !shouldRequest) return true;
+    const requested = await this._checkRequested(options);
+    if (requested) return true;
+    const shouldRequest = await this._shouldRequest(options);
+    if (!shouldRequest) return true;
+    const allowedRobot = await this._checkAllowedRobots(options);
+    if (!allowedRobot) return true;
     return false;
   }
 


### PR DESCRIPTION
Fixes: https://github.com/yujiosaka/headless-chrome-crawler/issues/199

FYI @panthony