### PR TITLE
chore: bump version to 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,24 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.6.0] - 2018-04-21
+
+### Added
+
+- Support `viewport` and `skipRequestedRedirect` for [crawler.queue()](https://github.com/yujiosaka/headless-chrome-crawler/blob/master/API.md#crawlerqueueoptions)'s options.
+- Emit `requestdisallowed` event.
+- Make `onSuccess` pass `redirectChain` in the response.
+
 ### changed
 
 - Bump Node.js version up to 8.10.0.
+- Update [Puppeteer](https://github.com/GoogleChrome/puppeteer) version to 1.3.0.
 - Move [node_redis](https://github.com/NodeRedis/node_redis) to the peer dependencies.
 - Make [crawler.queue()](https://github.com/yujiosaka/headless-chrome-crawler/blob/master/API.md#crawlerqueueoptions) to return Promise.
+
+### Fixed
+
+- Fix a bug of silently failing to insert jQuery due to CSP.
 
 ## [1.5.0] - 2018-03-25
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headless-chrome-crawler",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Distributed web crawler powered by Headless Chrome",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## [1.6.0] - 2018-04-21

### Added

- Support `viewport` and `skipRequestedRedirect` for [crawler.queue()](https://github.com/yujiosaka/headless-chrome-crawler/blob/master/API.md#crawlerqueueoptions)'s options.
- Emit `requestdisallowed` event.
- Make `onSuccess` pass `redirectChain` in the response.

### changed

- Bump Node.js version up to 8.10.0.
- Update [Puppeteer](https://github.com/GoogleChrome/puppeteer) version to 1.3.0.
- Move [node_redis](https://github.com/NodeRedis/node_redis) to the peer dependencies.
- Make [crawler.queue()](https://github.com/yujiosaka/headless-chrome-crawler/blob/master/API.md#crawlerqueueoptions) to return Promise.

### Fixed

- Fix a bug of silently failing to insert jQuery due to CSP.