### PR TITLE
Feature for custom scrape by page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Support for a custom scrape function using the puppeteer [page](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#class-page) object.
 
 ## [1.6.0] - 2018-04-21
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ const HCCrawler = require('headless-chrome-crawler');
     evaluatePage: (() => ({
       title: $('title').text(),
     })),
+    // Override default scrape function when using this option evaluatePage will be ignored
+    // customScrape: (page) => {
+    //  return page.title();
+    // },
     // Function to be called with evaluated results from browsers
     onSuccess: (result => {
       console.log(result);

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -214,8 +214,12 @@ class Crawler {
    * @private
    */
   async _scrape() {
-    if (!this._options.evaluatePage) return null;
+    if (!this._options.evaluatePage && !this._options.customScrape) return null;
     await this._addJQuery();
+    if(this._options.customScrape) {
+      return this._options.customScrape(this._page);
+    }
+
     return this._page.evaluate(this._options.evaluatePage);
   }
 


### PR DESCRIPTION
Hi all,

I was a bit struggling with the evaluatePage function by not getting all the cookies.
So i decided to expand the _scraper so that people can create custom scrape functions with the full page class from puppeteer. This is a awesome way to scrape in because then you can collect more data for example the page.cookies etc.

This was a quick fix if people have other ideas to do this please say it so we can discuss it! 