### PR TITLE
chore(package): move husky to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "homepage": "https://github.com/yujiosaka/headless-chrome-crawler#readme",
   "dependencies": {
     "debug": "3.1.0",
-    "husky": "0.14.3",
     "jquery": "3.3.1",
     "lodash": "4.17.5",
     "puppeteer": "1.4.0",
@@ -49,6 +48,7 @@
     "eslint-config-airbnb": "16.1.0",
     "eslint-plugin-import": "2.11.0",
     "greenkeeper-lockfile": "1.15.0",
+    "husky": "^0.14.3",
     "mime": "2.3.0",
     "mocha": "mochajs/mocha#88b9882",
     "power-assert": "1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -168,9 +168,9 @@
   version "9.6.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.2.tgz#e49ac1adb458835e95ca6487bc20f916b37aff23"
 
-"@types/node@10.0.3":
-  version "10.0.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.0.3.tgz#1f89840c7aac2406cc43a2ecad98fc02a8e130e4"
+"@types/node@10.0.7":
+  version "10.0.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.0.7.tgz#c1c9e2a68be8c1544c8761012cd6cf722949691f"
 
 "@types/puppeteer@1.2.3":
   version "1.2.3"
@@ -1019,9 +1019,9 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.3:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
-greenkeeper-lockfile@1.14.0:
-  version "1.14.0"
-  resolved "https://registry.yarnpkg.com/greenkeeper-lockfile/-/greenkeeper-lockfile-1.14.0.tgz#c6c25d62cd08fcd30ccdb5f11f171f7c80a1a7ce"
+greenkeeper-lockfile@1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/greenkeeper-lockfile/-/greenkeeper-lockfile-1.15.0.tgz#f989b6833a09e07176d2f9410a5f8eec59ae5fc7"
   dependencies:
     lodash "^4.17.4"
     require-relative "^0.8.7"
@@ -1098,7 +1098,7 @@ https-proxy-agent@^2.1.0:
     agent-base "^4.1.0"
     debug "^3.1.0"
 
-husky@0.14.3:
+husky@^0.14.3:
   version "0.14.3"
   resolved "https://registry.yarnpkg.com/husky/-/husky-0.14.3.tgz#c69ed74e2d2779769a17ba8399b54ce0b63c12c3"
   dependencies:


### PR DESCRIPTION
It was incorrectly installed to dependencies.
It's not used in production of course, so should be moved to devDependencies.