### PR TITLE
chore: bump version to 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.6.0] - 2018-05-14
+
 ### Added
 
 - Support `cookies` for [crawler.queue()](https://github.com/yujiosaka/headless-chrome-crawler/blob/master/API.md#crawlerqueueoptions)'s options.
 - Make `onSuccess` pass `cookies` in the response.
+
+### changed
+
+- Update [Puppeteer](https://github.com/GoogleChrome/puppeteer) version to 1.4.0.
 
 ## [1.6.0] - 2018-04-21
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "homepage": "https://github.com/yujiosaka/headless-chrome-crawler#readme",
   "dependencies": {
     "debug": "3.1.0",
-    "husky": "0.14.3",
     "jquery": "3.3.1",
     "lodash": "4.17.5",
     "puppeteer": "1.4.0",
@@ -49,6 +48,7 @@
     "eslint-config-airbnb": "16.1.0",
     "eslint-plugin-import": "2.11.0",
     "greenkeeper-lockfile": "1.15.0",
+    "husky": "0.14.3",
     "mime": "2.3.0",
     "mocha": "mochajs/mocha#88b9882",
     "power-assert": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headless-chrome-crawler",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Distributed web crawler powered by Headless Chrome",
   "main": "index.js",
   "license": "MIT",
@@ -26,6 +26,7 @@
   "homepage": "https://github.com/yujiosaka/headless-chrome-crawler#readme",
   "dependencies": {
     "debug": "3.1.0",
+    "husky": "0.14.3",
     "jquery": "3.3.1",
     "lodash": "4.17.5",
     "puppeteer": "1.4.0",
@@ -48,7 +49,6 @@
     "eslint-config-airbnb": "16.1.0",
     "eslint-plugin-import": "2.11.0",
     "greenkeeper-lockfile": "1.15.0",
-    "husky": "^0.14.3",
     "mime": "2.3.0",
     "mocha": "mochajs/mocha#88b9882",
     "power-assert": "1.5.0",


### PR DESCRIPTION
### Added

- Support `cookies` for [crawler.queue()](https://github.com/yujiosaka/headless-chrome-crawler/blob/master/API.md#crawlerqueueoptions)'s options.
- Make `onSuccess` pass `cookies` in the response.

### changed

- Update [Puppeteer](https://github.com/GoogleChrome/puppeteer) version to 1.4.0.