### PR TITLE
test(ci): use docker image for headless chrome crawler

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: yujiosaka/headless-chrome-linux
+      - image: yujiosaka/headless-chrome-crawler-linux
       - image: redis
     steps:
       - checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,14 +25,5 @@ RUN chmod +x /usr/local/bin/dumb-init
 # Install puppeteer so it's available in the container.
 RUN yarn add headless-chrome-crawler
 
-# Add user so we don't need --no-sandbox.
-RUN groupadd -r crawler && useradd -r -g crawler -G audio,video crawler \
-    && mkdir -p /home/crawler/Downloads \
-    && chown -R crawler:crawler /home/crawler \
-    && chown -R crawler:crawler /node_modules
-
-# Run everything after as non-privileged user.
-USER crawler
-
 ENTRYPOINT ["dumb-init", "--"]
 CMD ["google-chrome-unstable"]


### PR DESCRIPTION
Use docker image composed with [this script](https://github.com/yujiosaka/headless-chrome-crawler/blob/master/Dockerfile).