### PR TITLE
feat: added support for "evaluatePageArgs" #306

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -234,6 +234,7 @@ url, allowedDomains, deniedDomains, timeout, priority, depthPriority, delay, ret
     * `secure` <[boolean]>
     * `sameSite` <[string]> `"Strict"` or `"Lax"`.
   * `evaluatePage()` <[Function]> Function to be evaluated in browsers. Return serializable object. If it's not serializable, the result will be `undefined`.
+  * `evaluatePageArgs` <[Object]> Arguments which pass to the evaluatePage().
 * returns: <[Promise]> Promise resolved when queue is pushed.
 
 > **Note**: `response.url` may be different from `options.url` especially when the requested url is redirected.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Support `evaluatePageArgs` for [HCCrawler.launch()](https://github.com/yujiosaka/headless-chrome-crawler/blob/master/docs/API.md#hccrawlerlaunchoptions)'s options.
+
 ## [1.8.0] - 2018-06-11
 
 ### Added

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -242,7 +242,7 @@ class Crawler {
   async _scrape() {
     if (!this._options.evaluatePage) return null;
     await this._addJQuery();
-    return this._page.evaluate(this._options.evaluatePage);
+    return this._page.evaluate(this._options.evaluatePage, this._options.evaluatePageArgs);
   }
 
   /**

--- a/lib/hccrawler.js
+++ b/lib/hccrawler.js
@@ -160,7 +160,6 @@ class HCCrawler extends EventEmitter {
         if (queueOptions && queueOptions[option]) throw new Error(`Overriding ${option} is not allowed!`);
       });
       const mergedOptions = extend({}, this._options, queueOptions);
-      if (mergedOptions.evaluatePage) mergedOptions.evaluatePage = `(${mergedOptions.evaluatePage})()`;
       if (!mergedOptions.url) throw new Error('Url must be defined!');
       if (mergedOptions.device && !includes(deviceNames, mergedOptions.device)) throw new Error('Specified device is not supported!');
       if (mergedOptions.delay > 0 && mergedOptions.maxConcurrency !== 1) throw new Error('Max concurrency must be 1 when delay is set!');


### PR DESCRIPTION
This PR is supports evaluatePageArgs for passing arguments to page.evaluatePage.

I don't know why [hccrawler.js#L163](https://github.com/yujiosaka/headless-chrome-crawler/blob/master/lib/hccrawler.js#L163) use template string.

Officially, pageFunction on page.evaluate allow <function|sting> type. [official docs](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pageevaluatepagefunction-args)


### examples
```
HCCrawler.launch({
    evaluatePage: ((args) => ({
        title: $('title').text()
        foo: args.arg1,
        bar: args.arg2
    })),
    evaluatePageArgs: {
        arg1 : 'foo',
        arg2 : 'bar',
    },
…
})
```