### PR TITLE
fix greenkeeper

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,8 @@ jobs:
           keys:
           - v1-dependencies-{{ checksum "package.json" }}
           - v1-dependencies-
+      - run: apt-get update
+      - run: apt-get install -y git ssh
       - run: yarn install
       - save_cache:
           paths:


### PR DESCRIPTION
It appears that the `greenkeeper` builds are failing on account of the `git` package missing from the `yujiosaka/headless-chrome-crawler-linux` image.

Installing `git` and `ssh` in accordance with https://circleci.com/docs/2.0/custom-images/#required-tools-for-primary-containers. All the other required packages are already present.