### PR TITLE
Check for a non-null document before looking for links

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -284,12 +284,13 @@ class Crawler {
     });
     await this._page.evaluate(() => {
       function findLinks(document) {
-        document.querySelectorAll('a[href]')
+        if (document != null) {
+          document.querySelectorAll('a[href]')
           .forEach(link => {
             // @ts-ignore
             window.pushToLinks(link.href);
           });
-        document.querySelectorAll('iframe,frame')
+          document.querySelectorAll('iframe,frame')
           .forEach(frame => {
             try {
               findLinks(frame.contentDocument);
@@ -299,6 +300,7 @@ class Crawler {
               if (frame.src) window.pushToLinks(frame.src);
             }
           });
+        }
       }
       findLinks(window.document);
     });


### PR DESCRIPTION
I've ran into an error on a page containing frames where for some reason `document` was being passed in as null. This check fixed the error.